### PR TITLE
Fix package installation: include datasources subpackage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ select = ["F", "I", "E", "W", "UP", "C4", "ARG"]
 ignore = ["E501"]
 
 [tool.setuptools]
-packages = ["geollm"]
+packages = { find = { where = ["."], include = ["geollm*"] } }
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]


### PR DESCRIPTION
## Problem
The `geollm.datasources` subpackage was not included in package installations, causing `ImportError` when importing `SwissNames3DSource` and other datasources.

## Solution
Updated `pyproject.toml` to use automatic package discovery instead of explicitly listing packages. This ensures all subpackages under `geollm` are included in the distribution.