### PR TITLE
Add db source

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -101,6 +101,18 @@ Resolves location names to geometries.
     - Type filtering with fuzzy matching (lake, city, canton, etc.)
     - Coordinate conversion (CH1903+ → WGS84)
     - ~80 grouped geographic types
+  - `IGNBDCartoSource`: Wraps IGN BD-CARTO data (GeoPackage). Handles:
+    - 13 thematic layers (administrative, hydrography, named places, protected areas)
+    - French article stripping for name normalization
+    - Coordinate conversion (Lambert-93 → WGS84)
+  - `PostGISDataSource`: Generic DB-backed datasource for any PostGIS table. Handles:
+    - Accepts a SQLAlchemy `Engine` or a connection URL string (DB-agnostic)
+    - ILIKE-based case-insensitive search with `pg_trgm` fuzzy fallback
+    - CRS reprojection via `ST_Transform` when the stored CRS differs from WGS84
+    - Optional `type_map` for normalizing raw DB type values to the etter hierarchy
+    - No driver is bundled — the user provides it via the connection URL
+      (e.g. `postgresql+psycopg2://...`)
+  - `CompositeDataSource`: Fan-out aggregator over multiple datasources
 
 ### 3. Spatial Operations (Layer 3)
 
@@ -290,10 +302,120 @@ etter/
 ├── datasources/           # Layer 2: Data Resolution
 │   ├── protocol.py        # GeoDataSource Protocol
 │   ├── location_types.py  # Type hierarchy & fuzzy matching
-│   └── swissnames3d.py    # SwissNames3D Implementation
+│   ├── swissnames3d.py    # SwissNames3D Implementation (Shapefile)
+│   ├── ign_bdcarto.py     # IGN BD-CARTO Implementation (GeoPackage)
+│   ├── postgis.py         # PostGISDataSource (generic DB-backed)
+│   └── composite.py       # Fan-out aggregator
 ├── spatial.py             # Layer 3: Geometry Transformation
 └── __init__.py            # Public exports
+
+demo/
+├── main.py                # FastAPI demo server (file-based or PostGIS mode)
+├── Dockerfile             # Image for the FastAPI service
+├── docker-compose.yml     # PostGIS demo stack (see below)
+└── static/                # OpenLayers map UI
+
+scripts/
+├── extract_bdcarto.sh     # Extract IGN 7z archive
+└── load_data_postgis.py   # Load shapefiles/gpkg into PostGIS
 ```
+
+---
+
+## PostGIS Demo Stack
+
+The `demo/docker-compose.yml` provides a fully containerised version of the
+demo using PostGIS as the geodata backend.
+
+### Services
+
+| Service | Image / Build | Purpose |
+|---|---|---|
+| `postgis` | `postgis/postgis:18-3.6` | PostgreSQL 18 + PostGIS; stores data in `/var/lib/postgresql` |
+| `data-loader` | `demo/Dockerfile` | One-shot container; runs `scripts/load_data_postgis.py` then exits |
+| `api` | `demo/Dockerfile` | FastAPI server; starts after `data-loader` completes successfully |
+
+### Normalized Table Schema
+
+Both datasets are loaded into PostGIS using the same unified schema:
+
+```sql
+CREATE TABLE public.swissnames3d (
+    id    TEXT,
+    name  TEXT NOT NULL,
+    type  TEXT,
+    geom  GEOMETRY(Geometry, 4326)
+);
+
+CREATE TABLE public.ign_bdcarto (
+    id    TEXT,
+    name  TEXT NOT NULL,
+    type  TEXT,
+    geom  GEOMETRY(Geometry, 4326)
+);
+```
+
+All geometries are stored in WGS84 (EPSG:4326). The loader reprojects from
+the native CRS (EPSG:2056 for SwissNames3D, EPSG:2154 for IGN BD-CARTO) at
+load time.
+
+### Quick Start
+
+```bash
+# 1. Download geodata (if not already present)
+make download-data          # SwissNames3D shapefiles → data/
+make download-data-ign      # IGN BD-CARTO gpkg files → data/bdcarto/
+
+# 2. Set your OpenAI API key
+export OPENAI_API_KEY=sk-...
+
+# 3. Start the full stack
+docker compose -f demo/docker-compose.yml up
+
+# The API is available at http://localhost:8000
+```
+
+### Environment Variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `ETTER_DB_URL` | — | SQLAlchemy connection URL; enables PostGIS mode in `demo/main.py` |
+| `POSTGRES_USER` | `etter` | PostgreSQL user |
+| `POSTGRES_PASSWORD` | `etter` | PostgreSQL password |
+| `POSTGRES_DB` | `geodata` | PostgreSQL database name |
+| `SWISSNAMES3D_TABLE` | `swissnames3d` | Target table for SwissNames3D |
+| `IGN_BDCARTO_TABLE` | `ign_bdcarto` | Target table for IGN BD-CARTO |
+| `DB_SCHEMA` | `public` | PostgreSQL schema |
+
+### Demo Mode Selection
+
+`demo/main.py` auto-detects which mode to use:
+
+- **PostGIS mode** — when `ETTER_DB_URL` is set (used by docker-compose)
+- **File mode** — when `ETTER_DB_URL` is absent (original behaviour; uses `SWISSNAMES3D_PATH` / `IGN_BDCARTO_PATH`)
+
+---
+
+### Installing the PostGIS Extra
+
+To use `PostGISDataSource` outside the demo (e.g., in your own application):
+
+```bash
+pip install etter[postgis]          # installs sqlalchemy + geoalchemy2
+pip install psycopg2-binary         # or your preferred driver
+```
+
+```python
+from etter.datasources import PostGISDataSource
+
+source = PostGISDataSource(
+    connection="postgresql+psycopg2://user:pass@localhost/mydb",
+    table="public.my_geodata",
+)
+results = source.search("Lausanne", type="city")
+```
+
+---
 
 ---
 
@@ -301,7 +423,8 @@ etter/
 
 - **LLM**: Provider, Model, Temperature
 - **Spatial**: Default distances, buffer offsets
-- **Datasource**: Path to SwissNames3D data file
+- **Datasource (file mode)**: Path to SwissNames3D shapefiles / IGN BD-CARTO GeoPackages
+- **Datasource (PostGIS mode)**: SQLAlchemy connection URL + table names
 
 ---
 
@@ -309,18 +432,21 @@ etter/
 
 All three layers are **fully implemented and integrated**:
 
-- ✅ **Layer 1 (Parser)**: Complete - Extracts spatial relations from natural language using LLM
-- ✅ **Layer 2 (Datasource)**: Complete - SwissNames3D resolves location names to WGS84 geometries
-- ✅ **Layer 3 (Spatial Operations)**: Complete - Transforms geometries using spatial relations (buffers, directional sectors, etc.)
-- ✅ **Integration**: Full end-to-end workflow with demo API server
+- ✅ **Layer 1 (Parser)**: Complete — Extracts spatial relations from natural language using LLM
+- ✅ **Layer 2 (Datasource)**: Complete — Multiple implementations:
+  - `SwissNames3DSource` — swisstopo shapefiles → WGS84 GeoJSON
+  - `IGNBDCartoSource` — IGN BD-CARTO GeoPackages → WGS84 GeoJSON
+  - `PostGISDataSource` — generic PostGIS table → WGS84 GeoJSON (DB-agnostic)
+  - `CompositeDataSource` — fan-out aggregator
+- ✅ **Layer 3 (Spatial Operations)**: Complete — Transforms geometries using spatial relations (buffers, directional sectors, etc.)
+- ✅ **Integration**: Full end-to-end workflow with demo API server (file mode and PostGIS mode)
 
-The demo API at `/demo/main.py` demonstrates the complete pipeline:
+The demo API at `demo/main.py` demonstrates the complete pipeline:
 ```
 Query → Parser → Datasource → Spatial Ops → GeoJSON Result
 ```
 
 ## Not Yet Implemented
 
-- Additional datasource implementations (beyond SwissNames3D)
 - Complex query types: `compound` (multi-step), `split` (area division), `boolean` (AND/OR/NOT)
 - Some edge cases in spatial operations

--- a/demo/.env.example
+++ b/demo/.env.example
@@ -1,0 +1,4 @@
+OPENAI_API_KEY=sk-...
+POSTGRES_USER=your_db_user
+POSTGRES_PASSWORD=your_db_password
+POSTGRES_DB=geodata

--- a/demo/Dockerfile
+++ b/demo/Dockerfile
@@ -1,0 +1,21 @@
+FROM python:3.12-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    libpq-dev \
+    libgdal-dev \
+    gdal-bin \
+    python3-gdal \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+
+COPY . .
+
+RUN uv sync --extra dev --extra postgis --frozen
+
+EXPOSE 8000
+
+CMD ["uv", "run", "uvicorn", "demo.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/demo/docker-compose.yml
+++ b/demo/docker-compose.yml
@@ -7,6 +7,7 @@ services:
       POSTGRES_DB: ${POSTGRES_DB:-geodata}
     volumes:
       - postgis_data:/var/lib/postgresql
+      - ./initdb:/docker-entrypoint-initdb.d:ro
     ports:
       - "5432:5432"
     healthcheck:

--- a/demo/docker-compose.yml
+++ b/demo/docker-compose.yml
@@ -1,0 +1,66 @@
+services:
+  postgis:
+    image: postgis/postgis:18-3.6
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB:-geodata}
+    volumes:
+      - postgis_data:/var/lib/postgresql
+    ports:
+      - "5432:5432"
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB:-geodata}",
+        ]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+    restart: unless-stopped
+
+  data-loader:
+    build:
+      context: ..
+      dockerfile: demo/Dockerfile
+    command: >
+      uv run python scripts/load_data_postgis.py
+    environment:
+      ETTER_DB_URL: >-
+        postgresql+psycopg2://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgis:5432/${POSTGRES_DB:-geodata}
+      SWISSNAMES3D_PATH: /data
+      IGN_BDCARTO_PATH: /data/bdcarto
+      SWISSNAMES3D_TABLE: ${SWISSNAMES3D_TABLE:-swissnames3d}
+      IGN_BDCARTO_TABLE: ${IGN_BDCARTO_TABLE:-ign_bdcarto}
+      IF_EXISTS: ${IF_EXISTS:-replace}
+    volumes:
+      - ../data:/data:ro
+      - ../scripts:/app/scripts:ro
+    depends_on:
+      postgis:
+        condition: service_healthy
+    restart: "no"
+
+  api:
+    build:
+      context: ..
+      dockerfile: demo/Dockerfile
+    ports:
+      - "8000:8000"
+    environment:
+      OPENAI_API_KEY: ${OPENAI_API_KEY}
+      # PostGIS mode: set ETTER_DB_URL to use PostGISDataSource
+      ETTER_DB_URL: >-
+        postgresql+psycopg2://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgis:5432/${POSTGRES_DB:-geodata}
+      SWISSNAMES3D_TABLE: ${SWISSNAMES3D_TABLE:-swissnames3d}
+      IGN_BDCARTO_TABLE: ${IGN_BDCARTO_TABLE:-ign_bdcarto}
+    depends_on:
+      postgis:
+        condition: service_healthy
+      data-loader:
+        condition: service_completed_successfully
+    restart: unless-stopped
+
+volumes:
+  postgis_data:

--- a/demo/initdb/01_extensions.sql
+++ b/demo/initdb/01_extensions.sql
@@ -1,0 +1,4 @@
+-- Enable extensions strongly recommended for better search results.
+-- The pg_trgm extension provides fuzzy string matching, and unaccent helps with diacritics.
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+CREATE EXTENSION IF NOT EXISTS unaccent;

--- a/demo/main.py
+++ b/demo/main.py
@@ -16,6 +16,8 @@ from mcp.server.fastmcp.exceptions import ToolError
 from pydantic import BaseModel
 
 from etter.datasources import CompositeDataSource, IGNBDCartoSource, PostGISDataSource, SwissNames3DSource
+from etter.datasources.ign_bdcarto import IGN_BDCARTO_TYPE_MAP
+from etter.datasources.swissnames3d import OBJEKTART_TYPE_MAP
 from etter.parser import GeoFilterParser
 from etter.spatial import apply_spatial_relation
 
@@ -63,6 +65,7 @@ if ETTER_DB_URL:
         PostGISDataSource(
             connection=ETTER_DB_URL,
             table=swissnames_table,
+            type_map=OBJEKTART_TYPE_MAP,
         )
     )
 
@@ -71,6 +74,7 @@ if ETTER_DB_URL:
         PostGISDataSource(
             connection=ETTER_DB_URL,
             table=bdcarto_table,
+            type_map=IGN_BDCARTO_TYPE_MAP,
         )
     )
 else:

--- a/demo/main.py
+++ b/demo/main.py
@@ -15,7 +15,7 @@ from mcp.server.fastmcp import FastMCP
 from mcp.server.fastmcp.exceptions import ToolError
 from pydantic import BaseModel
 
-from etter.datasources import CompositeDataSource, IGNBDCartoSource, SwissNames3DSource
+from etter.datasources import CompositeDataSource, IGNBDCartoSource, PostGISDataSource, SwissNames3DSource
 from etter.parser import GeoFilterParser
 from etter.spatial import apply_spatial_relation
 
@@ -35,7 +35,6 @@ async def lifespan(_app: FastAPI):
 
 app = FastAPI(title="etter Demo", lifespan=lifespan)
 
-# Enable CORS (for development)
 app.add_middleware(
     CORSMiddleware,
     allow_origins=["*"],
@@ -45,35 +44,59 @@ app.add_middleware(
 )
 
 # Data source configuration
-SWISSNAMES3D_PATH = os.getenv("SWISSNAMES3D_PATH", "data")
-IGN_BDCARTO_PATH = os.getenv("IGN_BDCARTO_PATH", "data/bdcarto")
+#
+# When ETTER_DB_URL is set the demo uses PostGISDataSource (DB-backed).
+# Otherwise it falls back to the original file-based sources (SwissNames3D
+# shapefiles and IGN BD-CARTO GeoPackages).
 
-if not os.path.exists(SWISSNAMES3D_PATH):
-    raise RuntimeError(
-        f"SwissNames3D data not found at {SWISSNAMES3D_PATH}. Please set SWISSNAMES3D_PATH environment variable."
-    )
+ETTER_DB_URL = os.getenv("ETTER_DB_URL")
 
-# Build datasource(s) and combine into a composite
 sources = []
 
-print(f"Loading SwissNames3D from {SWISSNAMES3D_PATH}...")
-sources.append(SwissNames3DSource(SWISSNAMES3D_PATH))
+if ETTER_DB_URL:
+    SWISSNAMES3D_TABLE = os.getenv("SWISSNAMES3D_TABLE", "swissnames3d")
+    IGN_BDCARTO_TABLE = os.getenv("IGN_BDCARTO_TABLE", "ign_bdcarto")
+    DB_SCHEMA = os.getenv("DB_SCHEMA", "public")
 
-if os.path.exists(IGN_BDCARTO_PATH):
-    print(f"Loading IGN BD-CARTO from {IGN_BDCARTO_PATH}...")
-    try:
-        ign_source = IGNBDCartoSource(IGN_BDCARTO_PATH)
-        # Verify at least one layer is present before adding
-        ign_source.get_available_types()  # triggers lazy load
-        sources.append(ign_source)
-    except ValueError as e:
-        print(f"IGN BD-CARTO not loaded: {e}")
+    swissnames_table = f"{DB_SCHEMA}.{SWISSNAMES3D_TABLE}"
+    sources.append(
+        PostGISDataSource(
+            connection=ETTER_DB_URL,
+            table=swissnames_table,
+        )
+    )
+
+    bdcarto_table = f"{DB_SCHEMA}.{IGN_BDCARTO_TABLE}"
+    sources.append(
+        PostGISDataSource(
+            connection=ETTER_DB_URL,
+            table=bdcarto_table,
+        )
+    )
 else:
-    print(f"IGN BD-CARTO path not found ({IGN_BDCARTO_PATH}), skipping.")
+    SWISSNAMES3D_PATH = os.getenv("SWISSNAMES3D_PATH", "data")
+    IGN_BDCARTO_PATH = os.getenv("IGN_BDCARTO_PATH", "data/bdcarto")
+
+    if not os.path.exists(SWISSNAMES3D_PATH):
+        raise RuntimeError(
+            f"SwissNames3D data not found at {SWISSNAMES3D_PATH}. "
+            "Set SWISSNAMES3D_PATH or provide ETTER_DB_URL for PostGIS mode."
+        )
+
+    sources.append(SwissNames3DSource(SWISSNAMES3D_PATH))
+
+    if os.path.exists(IGN_BDCARTO_PATH):
+        try:
+            ign_source = IGNBDCartoSource(IGN_BDCARTO_PATH)
+            ign_source.get_available_types()
+            sources.append(ign_source)
+        except ValueError as e:
+            logger.warning("IGN BD-CARTO not loaded: %s", e)
+    else:
+        logger.warning("IGN BD-CARTO path not found (%s), skipping.", IGN_BDCARTO_PATH)
 
 datasource = CompositeDataSource(*sources)
 
-# Initialize etter components
 llm = ChatOpenAI(model="gpt-4o", temperature=0)
 parser = GeoFilterParser(llm, datasource=datasource)
 
@@ -134,7 +157,7 @@ async def process_query(request: QueryRequest):
     except ValueError as e:
         raise HTTPException(status_code=404, detail=str(e))
     except Exception as e:
-        print(f"Error processing query: {e}")
+        logger.exception("Error processing query")
         raise HTTPException(status_code=500, detail=str(e))
 
 
@@ -161,24 +184,19 @@ async def process_query_stream(request: QueryRequest):
             # Stream parsing events
             parse_start = time.perf_counter()
             async for event in parser.parse_stream(request.query):
-                # Forward all events from parser
                 yield f"data: {json.dumps(event)}\n\n"
 
-                # Capture the final GeoQuery for spatial processing
                 if event["type"] == "data-response":
                     geo_query_result = event["content"]
             yield f"data: {json.dumps({'type': 'reasoning', 'content': 'LLM parsing', 'duration_ms': (time.perf_counter() - parse_start) * 1000})}\n\n"
 
-            # If we have a parsed query, process the spatial relations
             if geo_query_result:
                 yield f"data: {json.dumps({'type': 'reasoning', 'content': 'Resolving location in database'})}\n\n"
 
-                # Reconstruct GeoQuery from dict (for type safety)
                 from etter.models import GeoQuery
 
                 geo_query = GeoQuery.model_validate(geo_query_result)
 
-                # Resolve location
                 location_name = geo_query.reference_location.name
                 search_start = time.perf_counter()
                 logger.info(
@@ -197,7 +215,6 @@ async def process_query_stream(request: QueryRequest):
 
                 yield f"data: {json.dumps({'type': 'reasoning', 'content': f'Found {len(features)} matching location(s)', 'duration_ms': (time.perf_counter() - search_start) * 1000})}\n\n"
 
-                # Apply spatial relation to ALL matching features
                 yield f"data: {json.dumps({'type': 'reasoning', 'content': 'Computing spatial search areas'})}\n\n"
 
                 spatial_start = time.perf_counter()
@@ -205,13 +222,11 @@ async def process_query_stream(request: QueryRequest):
                 spatial_duration = (time.perf_counter() - spatial_start) * 1000
                 yield f"data: {json.dumps({'type': 'reasoning', 'content': 'Computed spatial relations', 'duration_ms': spatial_duration})}\n\n"
 
-                # Construct final response
                 feature_collection = {
                     "type": "FeatureCollection",
                     "features": result_features,
                 }
 
-                # Send final result
                 final_response = {
                     "query": request.query,
                     "geo_query": geo_query_result,
@@ -224,7 +239,7 @@ async def process_query_stream(request: QueryRequest):
 
         except Exception as e:
             error_msg = f"Error during streaming: {str(e)}"
-            print(error_msg)
+            logger.exception("Error during streaming")
             yield f"data: {json.dumps({'type': 'error', 'content': error_msg})}\n\n"
 
     return StreamingResponse(event_generator(), media_type="text/event-stream")

--- a/etter/__init__.py
+++ b/etter/__init__.py
@@ -7,7 +7,7 @@ Parse location queries into structured geographic queries using LLM.
 # Main API
 # Exceptions
 # Datasources
-from .datasources import GeoDataSource, SwissNames3DSource
+from .datasources import CompositeDataSource, GeoDataSource, IGNBDCartoSource, PostGISDataSource, SwissNames3DSource
 from .exceptions import (
     GeoFilterError,
     LowConfidenceError,
@@ -57,6 +57,9 @@ __all__ = [
     # Datasources
     "GeoDataSource",
     "SwissNames3DSource",
+    "IGNBDCartoSource",
+    "CompositeDataSource",
+    "PostGISDataSource",
     # Spatial
     "apply_spatial_relation",
 ]

--- a/etter/datasources/__init__.py
+++ b/etter/datasources/__init__.py
@@ -1,11 +1,13 @@
 """
 Geographic data source layer for resolving location names to geometries.
 
-Provides a Protocol-based interface for data sources and a SwissNames3D implementation.
+Provides a Protocol-based interface (GeoDataSource) and concrete implementations:
+SwissNames3DSource, IGNBDCartoSource, PostGISDataSource, and CompositeDataSource.
 """
 
 from .composite import CompositeDataSource
 from .ign_bdcarto import IGNBDCartoSource
+from .postgis import PostGISDataSource
 from .protocol import GeoDataSource
 from .swissnames3d import SwissNames3DSource
 
@@ -13,5 +15,6 @@ __all__ = [
     "CompositeDataSource",
     "GeoDataSource",
     "IGNBDCartoSource",
+    "PostGISDataSource",
     "SwissNames3DSource",
 ]

--- a/etter/datasources/composite.py
+++ b/etter/datasources/composite.py
@@ -35,9 +35,7 @@ class CompositeDataSource:
             raise ValueError("At least one datasource is required.")
         self._sources: list[GeoDataSource] = list(sources)
 
-    # ------------------------------------------------------------------
     # Public API (mirrors GeoDataSource protocol)
-    # ------------------------------------------------------------------
 
     def search(
         self,

--- a/etter/datasources/ign_bdcarto.py
+++ b/etter/datasources/ign_bdcarto.py
@@ -180,10 +180,17 @@ def _build_ign_type_map() -> dict[str, list[str]]:
     result: dict[str, list[str]] = {}
     for cfg in _LAYER_CONFIGS.values():
         raw_map: dict[str, str] | None = cfg.get("type_map")
-        if not raw_map:
-            continue
-        for raw_value, normalized in raw_map.items():
-            result.setdefault(normalized, []).append(raw_value)
+        if raw_map:
+            # Layers with a type_map store raw source values in the DB (e.g. "Estuaire",
+            # "Canal").  Map normalized → list of raw values for query-time translation.
+            for raw_value, normalized in raw_map.items():
+                result.setdefault(normalized, []).append(raw_value)
+        elif fixed := cfg.get("fixed_type"):
+            # Layers with a fixed_type store the normalized value directly in the DB
+            # (e.g. "river" for cours_d_eau).  The DB value IS the normalized type, so
+            # add an identity mapping so the query filter matches it.
+            if fixed not in result.get(fixed, []):
+                result.setdefault(fixed, []).append(fixed)
     return result
 
 
@@ -444,6 +451,7 @@ class IGNBDCartoSource:
 
         if type is not None:
             matching_types = get_matching_types(type)
+            print(f"Filtering results by type hint '{type}' → matching types: {matching_types}")
             if matching_types:
                 features = [f for f in features if f["properties"].get("type") in matching_types]
             else:

--- a/etter/datasources/ign_bdcarto.py
+++ b/etter/datasources/ign_bdcarto.py
@@ -175,6 +175,21 @@ _TYPE_COL = "_normalized_type"
 _NAME_COL = "_name"
 
 
+# Public type map
+def _build_ign_type_map() -> dict[str, list[str]]:
+    result: dict[str, list[str]] = {}
+    for cfg in _LAYER_CONFIGS.values():
+        raw_map: dict[str, str] | None = cfg.get("type_map")
+        if not raw_map:
+            continue
+        for raw_value, normalized in raw_map.items():
+            result.setdefault(normalized, []).append(raw_value)
+    return result
+
+
+IGN_BDCARTO_TYPE_MAP: dict[str, list[str]] = _build_ign_type_map()
+
+
 def _normalize_name(name: str) -> str:
     """Lowercase, strip diacritics for accent-insensitive matching."""
     nfkd = unicodedata.normalize("NFKD", name)
@@ -330,6 +345,7 @@ class IGNBDCartoSource:
 
             gdf[_NAME_COL] = gdf[name_col].astype(str)
             gdf[_TYPE_COL] = gdf.apply(lambda row, c=cfg: _derive_type(row, c), axis=1)
+            gdf["_layer"] = layer_name
             gdf = gdf.to_crs("EPSG:4326")
 
             gdfs.append(gdf)

--- a/etter/datasources/ign_bdcarto.py
+++ b/etter/datasources/ign_bdcarto.py
@@ -27,17 +27,15 @@ Expected data layout (produced by scripts/extract_bdcarto.sh):
 """
 
 import unicodedata
-from collections import defaultdict
 from pathlib import Path
 from typing import Any
 
 import geopandas as gpd
 import pandas as pd
 from rapidfuzz import fuzz
-from shapely.geometry import mapping, shape
-from shapely.ops import unary_union
+from shapely.geometry import mapping
 
-from .location_types import get_matching_types
+from .location_types import get_matching_types, merge_segments
 
 _PLAN_D_EAU_TYPES: dict[str, str] = {
     "Lac": "lake",
@@ -248,67 +246,6 @@ def _derive_type(row: pd.Series, cfg: dict[str, Any]) -> str:
     return "unknown"
 
 
-_MERGE_TYPES: frozenset[str] = frozenset(
-    [
-        # Hydrography
-        "river",
-        "lake",
-        "pond",
-        "glacier",
-        # Landforms
-        "mountain",
-        "peak",
-        "ridge",
-        "valley",
-        "plain",
-        "massif",
-        "pass",
-        # Protected areas / forests
-        "park",
-        "nature_reserve",
-        "forest",
-        # Transport linear features
-        "road",
-        "railway",
-        "bridge",
-        "tunnel",
-    ]
-)
-
-
-def _merge_segments(features: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    """
-    Merge features that share the same (name, type) by unioning their geometries,
-    but only for types listed in ``_MERGE_TYPES``.
-
-    Rivers, ridges and other continuous geographic features in BD-CARTO are
-    often split into many individual segments.  When the caller queries for
-    "l'Oise" they expect the full course of the river, not an arbitrary single
-    segment.  Settlement and administrative types (city, municipality, …) are
-    excluded because two French villages with the same name are distinct places
-    that must not be conflated.
-    """
-    groups: dict[tuple[str, str], list[dict[str, Any]]] = defaultdict(list)
-    for f in features:
-        props = f.get("properties", {})
-        key = (str(props.get("name", "")), str(props.get("type", "")))
-        groups[key].append(f)
-
-    merged: list[dict[str, Any]] = []
-    for (name, ftype), group_features in groups.items():
-        if len(group_features) == 1 or ftype not in _MERGE_TYPES:
-            merged.extend(group_features)
-        else:
-            geoms = [shape(f["geometry"]) for f in group_features if f.get("geometry") and f["geometry"].get("type")]
-            combined = unary_union(geoms)
-            base = dict(group_features[0].items())
-            base["geometry"] = mapping(combined)
-            bounds = combined.bounds
-            base["bbox"] = tuple(bounds) if bounds else None
-            merged.append(base)
-    return merged
-
-
 class IGNBDCartoSource:
     """
     Geographic data source backed by IGN's BD-CARTO 5.0 dataset.
@@ -496,7 +433,7 @@ class IGNBDCartoSource:
             else:
                 features = [f for f in features if f["properties"].get("type") == type.lower()]
 
-        features = _merge_segments(features)
+        features = merge_segments(features)
 
         return features[:max_results]
 

--- a/etter/datasources/location_types.py
+++ b/etter/datasources/location_types.py
@@ -1,5 +1,5 @@
 """
-Location type hierarchy and fuzzy matching for geographic features.
+Location type hierarchy, fuzzy matching, and geometry merging for geographic features.
 
 This module defines the standard type hierarchy used across all datasources.
 Each datasource maps its native types to this hierarchy, enabling consistent
@@ -9,6 +9,14 @@ The hierarchy is organized into categories (water, administrative, settlement, e
 to support fuzzy matching. For example, querying type="water" matches features
 of type "lake", "river", "pond", etc.
 """
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Any
+
+from shapely.geometry import mapping, shape
+from shapely.ops import unary_union
 
 # Type hierarchy: category → list of concrete types
 # This enables fuzzy matching (category matches multiple concrete types)
@@ -184,3 +192,70 @@ def get_matching_types(type_hint: str) -> list[str]:
 
     # Unknown type - return empty (no match)
     return []
+
+
+# Segment merging
+
+# Types for which same-name features should be merged into a single geometry.
+# Continuous geographic features (rivers, ridges, …) are often split into many
+# individual segments in source datasets.  Settlement and administrative types
+# are intentionally excluded — two places with the same name are distinct.
+MERGE_TYPES: frozenset[str] = frozenset(
+    [
+        # Hydrography
+        "river",
+        "lake",
+        "pond",
+        "glacier",
+        # Landforms
+        "mountain",
+        "peak",
+        "ridge",
+        "valley",
+        "plain",
+        "massif",
+        "pass",
+        # Protected areas / forests
+        "park",
+        "nature_reserve",
+        "forest",
+        # Transport linear features
+        "road",
+        "railway",
+        "bridge",
+        "tunnel",
+    ]
+)
+
+
+def merge_segments(features: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """
+    Merge features that share the same (name, type) by unioning their geometries,
+    but only for types listed in ``MERGE_TYPES``.
+
+    Rivers, ridges and other continuous geographic features are often split into
+    many individual segments in source datasets.  When the caller queries for
+    "Rhône" they expect the full course of the river, not an arbitrary single
+    segment.  Settlement and administrative types (city, municipality, …) are
+    excluded because two places with the same name are distinct and must not be
+    conflated.
+    """
+    groups: dict[tuple[str, str], list[dict[str, Any]]] = defaultdict(list)
+    for f in features:
+        props = f.get("properties", {})
+        key = (str(props.get("name", "")), str(props.get("type", "")))
+        groups[key].append(f)
+
+    merged: list[dict[str, Any]] = []
+    for (_name, ftype), group_features in groups.items():
+        if len(group_features) == 1 or ftype not in MERGE_TYPES:
+            merged.extend(group_features)
+        else:
+            geoms = [shape(f["geometry"]) for f in group_features if f.get("geometry") and f["geometry"].get("type")]
+            combined = unary_union(geoms)
+            base = dict(group_features[0].items())
+            base["geometry"] = mapping(combined)
+            bounds = combined.bounds
+            base["bbox"] = tuple(bounds) if bounds else None
+            merged.append(base)
+    return merged

--- a/etter/datasources/postgis.py
+++ b/etter/datasources/postgis.py
@@ -145,7 +145,7 @@ class PostGISDataSource:
         id_column: str = "id",
         crs: str = "EPSG:4326",
         type_map: dict[str, list[str]] | None = None,
-        fuzzy_threshold: float = 0.3,
+        fuzzy_threshold: float = 0.65,
     ) -> None:
         sa = _require_sqlalchemy()
 
@@ -173,6 +173,7 @@ class PostGISDataSource:
             self._raw_to_normalized = {}
 
         self._trgm_available: bool | None = None
+        self._unaccent_available: bool | None = None
 
     def _get_connection(self) -> Any:
         """Return a SQLAlchemy connection from the engine."""
@@ -190,6 +191,19 @@ class PostGISDataSource:
             logger.exception("Failed to check pg_trgm availability")
             self._trgm_available = False
         return self._trgm_available
+
+    def _check_unaccent(self, conn: Any) -> bool:
+        """Return True if the unaccent extension is available in the database."""
+        if self._unaccent_available is not None:
+            return self._unaccent_available
+        sa = _require_sqlalchemy()
+        try:
+            result = conn.execute(sa.text("SELECT 1 FROM pg_extension WHERE extname = 'unaccent'"))
+            self._unaccent_available = result.fetchone() is not None
+        except Exception:
+            logger.exception("Failed to check unaccent availability")
+            self._unaccent_available = False
+        return self._unaccent_available
 
     def _normalize_type(self, raw_type: str | None) -> str | None:
         """Translate a raw DB type value to its normalized etter name.
@@ -250,8 +264,8 @@ class PostGISDataSource:
         Uses a three-step cascade, stopping as soon as any step returns results:
 
         1. **Normalized exact match**
-        2. **ILIKE substring**
-        3. **pg_trgm fuzzy** (requires the ``pg_trgm`` extension).
+        2. **pg_trgm fuzzy with unaccent** (pg_trgm extension required and unaccent extension recommended)
+        3. **ILIKE substring**
 
         ``merge_segments`` is applied after all rows are fetched so that
         multi-segment linestrings (rivers, roads) are merged before the
@@ -293,11 +307,11 @@ class PostGISDataSource:
 
         if not features:
             with self._get_connection() as conn:
-                features = self._search_ilike(conn, sa, cols, name, type_filter_values, internal_limit)
+                features = self._search_fuzzy(conn, sa, cols, name, type_filter_values, internal_limit)
 
         if not features:
             with self._get_connection() as conn:
-                features = self._search_fuzzy(conn, sa, cols, name, type_filter_values, internal_limit)
+                features = self._search_ilike(conn, sa, cols, name, type_filter_values, internal_limit)
 
         features = merge_segments(features)
         return features[:max_results]
@@ -353,14 +367,27 @@ class PostGISDataSource:
         type_filter: list[str] | None,
         fetch_limit: int,
     ) -> list[dict[str, Any]]:
-        """Case-insensitive substring fallback using ``ILIKE '%name%'``."""
+        """Case-insensitive substring fallback using ``ILIKE '%name%'``.
+
+        When the ``unaccent`` extension is available, both the stored name column
+        and the pattern are accent-stripped so that e.g. ``"Rhone"`` matches
+        ``"Rhône"``.  Without ``unaccent``, standard ILIKE is used (case-insensitive
+        only).
+        """
         type_clause, type_params = self._type_filter_sql(type_filter)
+        normalized = _normalize_name(name)
+        if self._check_unaccent(conn):
+            name_expr = f"unaccent(lower({self._name_col}))"
+            pattern = f"%{normalized}%"
+        else:
+            name_expr = self._name_col
+            pattern = f"%{name}%"
         sql = sa.text(
             f"SELECT {cols} FROM {self._table} "  # noqa: S608
-            f"WHERE {self._name_col} ILIKE :pattern{type_clause} "
+            f"WHERE {name_expr} ILIKE :pattern{type_clause} "
             f"LIMIT :limit"
         )
-        params: dict[str, Any] = {"pattern": f"%{name}%", "limit": fetch_limit, **type_params}
+        params: dict[str, Any] = {"pattern": pattern, "limit": fetch_limit, **type_params}
         try:
             result = conn.execute(sql, params)
             return [self._row_to_feature(row) for row in result]
@@ -379,16 +406,28 @@ class PostGISDataSource:
     ) -> list[dict[str, Any]]:
         """Fuzzy fallback using pg_trgm similarity (if extension is available)."""
         if not self._check_trgm(conn):
+            logger.warning(
+                "pg_trgm extension not available. Fuzzy search disabled. Install it with: CREATE EXTENSION pg_trgm;"
+            )
             return []
+        normalized_query = _normalize_name(name)
+        if self._check_unaccent(conn):
+            name_expr = f"unaccent(lower({self._name_col}))"
+        else:
+            logger.warning(
+                "unaccent extension not available. Accent-insensitive fuzzy search degraded. "
+                "Install it with: CREATE EXTENSION unaccent;"
+            )
+            name_expr = f"lower({self._name_col})"
         type_clause, type_params = self._type_filter_sql(type_filter)
         sql = sa.text(
             f"SELECT {cols} FROM {self._table} "  # noqa: S608
-            f"WHERE similarity({self._name_col}, :name) > :threshold{type_clause} "
-            f"ORDER BY similarity({self._name_col}, :name) DESC "
+            f"WHERE word_similarity({name_expr}, :query) > :threshold{type_clause} "
+            f"ORDER BY word_similarity({name_expr}, :query) DESC "
             f"LIMIT :limit"
         )
         params: dict[str, Any] = {
-            "name": name,
+            "query": normalized_query,
             "threshold": self._fuzzy_threshold,
             "limit": fetch_limit,
             **type_params,

--- a/etter/datasources/postgis.py
+++ b/etter/datasources/postgis.py
@@ -1,8 +1,16 @@
 """
 PostGIS data source implementation.
 
-Generic datasource backed by any PostGIS-enabled PostgreSQL table using a
-unified normalized schema (id, name, type, geom).
+Generic datasource backed by any PostGIS-enabled PostgreSQL table.  The
+table may store native dataset-specific type values (e.g. SwissNames3D's
+``"See"``, ``"Berg"``) or already-normalized etter type names (e.g.
+``"lake"``, ``"mountain"``).
+
+When native values are stored, pass a ``type_map`` mapping normalized etter
+type names to lists of raw column values, the same format as
+``SwissNames3DSource.OBJEKTART_TYPE_MAP``.  The datasource then translates
+in both directions: raw → normalized for output, normalized → raw for SQL
+type filters.
 
 The datasource is DB-agnostic: the caller provides either a SQLAlchemy
 Engine or a connection URL string.  No specific driver is bundled — the
@@ -54,8 +62,8 @@ class PostGISDataSource:
     """
     Geographic data source backed by a PostGIS table.
 
-    Expects the table to follow the unified normalized schema produced by the
-    ``scripts/load_data_postgis.py`` loader:
+    The table must expose at minimum a name column, a geometry column, and
+    optionally a type column. The expected schema is:
 
     .. code-block:: sql
 
@@ -66,9 +74,16 @@ class PostGISDataSource:
             geom    GEOMETRY(Geometry, 4326)
         );
 
-    Geometries must already be in WGS84 (EPSG:4326).  If your data lives in a
-    different CRS, reproject it before storing or set ``crs`` accordingly and
-    the datasource will reproject on the fly using ``pyproj``.
+    The ``type`` column may store either:
+
+    - **Raw dataset values** (e.g. ``"See"``, ``"Berg"`` for SwissNames3D),
+      pass ``type_map`` so the datasource can translate between raw values and
+      the normalized etter type names.
+    - **Already-normalized values** (e.g. ``"lake"``, ``"mountain"``),
+      leave ``type_map=None`` (default).
+
+    Geometries must be in WGS84 (EPSG:4326) or supply ``crs`` for on-the-fly
+    reprojection.
 
     Args:
         connection: A SQLAlchemy :class:`~sqlalchemy.engine.Engine` **or** a
@@ -81,21 +96,42 @@ class PostGISDataSource:
         geometry_column: PostGIS geometry column (default ``"geom"``).
         id_column: Primary-key column (default ``"id"``).
         crs: CRS of the stored geometries as an EPSG string.  Defaults to
-            ``"EPSG:4326"`` (no reprojection).  If a different CRS is supplied
-            geometries are reprojected to WGS84 before being returned.
-        type_map: Optional mapping of raw ``type`` column values to normalized
-            type strings used by the rest of the etter package.  When ``None``
-            the stored values are used as-is.
-        fuzzy_threshold: Minimum ``pg_trgm`` similarity score (0–1) used for
+            ``"EPSG:4326"`` (no reprojection).
+        type_map: Optional mapping from **normalized etter type names** to
+            **lists of raw type column values** present in the database.
+            This is the same format as ``SwissNames3DSource.OBJEKTART_TYPE_MAP``
+            and ``IGNBDCartoSource.IGN_BDCARTO_TYPE_MAP``, so they can be
+            passed directly::
+
+                from etter.datasources.swissnames3d import OBJEKTART_TYPE_MAP
+                source = PostGISDataSource(
+                    engine,
+                    table="public.swissnames3d",
+                    type_map=OBJEKTART_TYPE_MAP,
+                )
+
+            When ``type_map`` is provided the datasource:
+
+            - Translates raw DB values → normalized types in returned features.
+            - Translates user type hints → raw DB values in SQL ``WHERE`` clauses.
+            - Returns normalized type names from ``get_available_types()``.
+
+            When ``None`` (default) the stored values are used as-is.
+        fuzzy_threshold: Minimum ``pg_trgm`` similarity score (0-1) used for
             fuzzy fallback search when no exact ``ILIKE`` match is found.
 
-    Example::
+    Example: unmodified SwissNames3D table::
 
         from sqlalchemy import create_engine
         from etter.datasources import PostGISDataSource
+        from etter.datasources.swissnames3d import OBJEKTART_TYPE_MAP
 
-        engine = create_engine("postgresql+psycopg2://user:pass@localhost/geodata")
-        source = PostGISDataSource(engine, table="public.swissnames3d")
+        engine = create_engine(...)
+        source = PostGISDataSource(
+            engine,
+            table="public.swissnames3d",
+            type_map=OBJEKTART_TYPE_MAP,
+        )
         results = source.search("Lac Léman", type="lake")
     """
 
@@ -108,7 +144,7 @@ class PostGISDataSource:
         geometry_column: str = "geom",
         id_column: str = "id",
         crs: str = "EPSG:4326",
-        type_map: dict[str, str] | None = None,
+        type_map: dict[str, list[str]] | None = None,
         fuzzy_threshold: float = 0.3,
     ) -> None:
         sa = _require_sqlalchemy()
@@ -124,8 +160,17 @@ class PostGISDataSource:
         self._geom_col = geometry_column
         self._id_col = id_column
         self._crs = crs
-        self._type_map = type_map or {}
         self._fuzzy_threshold = fuzzy_threshold
+
+        # Build bidirectional lookup structures from the user-supplied map.
+        if type_map:
+            self._normalized_to_raw: dict[str, list[str]] = dict(type_map)
+            self._raw_to_normalized: dict[str, str] = {
+                raw: normalized for normalized, raws in type_map.items() for raw in raws
+            }
+        else:
+            self._normalized_to_raw = {}
+            self._raw_to_normalized = {}
 
         self._trgm_available: bool | None = None
 
@@ -147,10 +192,13 @@ class PostGISDataSource:
         return self._trgm_available
 
     def _normalize_type(self, raw_type: str | None) -> str | None:
-        """Apply type_map to a raw DB value, or return it unchanged."""
+        """Translate a raw DB type value to its normalized etter name.
+
+        If no type_map was supplied the value is returned unchanged.
+        """
         if raw_type is None:
             return None
-        return self._type_map.get(raw_type, raw_type)
+        return self._raw_to_normalized.get(raw_type, raw_type)
 
     def _row_to_feature(self, row: Any) -> dict[str, Any]:
         """Convert a SQLAlchemy Row to a GeoJSON Feature dict."""
@@ -220,11 +268,18 @@ class PostGISDataSource:
         sa = _require_sqlalchemy()
         cols = self._build_select_columns()
 
-        # Resolve type filter to concrete types via the hierarchy
+        # Resolve type filter to the raw DB values to use in the SQL WHERE clause.
         type_filter_values: list[str] | None = None
         if type is not None and self._type_col is not None:
             matching_types = get_matching_types(type)
-            type_filter_values = matching_types if matching_types else [type.lower()]
+            concrete_types = matching_types if matching_types else [type.lower()]
+            if self._normalized_to_raw:
+                raw_values: list[str] = []
+                for t in concrete_types:
+                    raw_values.extend(self._normalized_to_raw.get(t, [t]))
+                type_filter_values = raw_values if raw_values else concrete_types
+            else:
+                type_filter_values = concrete_types
 
         # Fetch more rows than requested so that merge_segments has the full
         # set of segments to work with.  Without this, a SQL LIMIT applied

--- a/etter/datasources/postgis.py
+++ b/etter/datasources/postgis.py
@@ -341,9 +341,12 @@ class PostGISDataSource:
         Python before the query is sent to the DB.
         """
         type_clause, type_params = self._type_filter_sql(type_filter)
+        name_expr = f"lower({self._name_col})"
+        if self._check_unaccent(conn):
+            name_expr = f"unaccent({name_expr})"
         sql = sa.text(
             f"SELECT {cols} FROM {self._table} "  # noqa: S608
-            f"WHERE lower({self._name_col}) = :query{type_clause} "
+            f"WHERE {name_expr} = :query{type_clause} "
             f"LIMIT :limit"
         )
         params: dict[str, Any] = {

--- a/etter/datasources/postgis.py
+++ b/etter/datasources/postgis.py
@@ -1,0 +1,430 @@
+"""
+PostGIS data source implementation.
+
+Generic datasource backed by any PostGIS-enabled PostgreSQL table using a
+unified normalized schema (id, name, type, geom).
+
+The datasource is DB-agnostic: the caller provides either a SQLAlchemy
+Engine or a connection URL string.  No specific driver is bundled — the
+user installs the driver they need (psycopg2, psycopg, asyncpg, …) and
+encodes it in the URL (e.g. ``postgresql+psycopg2://...``).
+
+Requires the optional ``[postgis]`` extras:
+    pip install etter[postgis]
+which pulls in ``sqlalchemy`` and ``geoalchemy2``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import unicodedata
+from typing import TYPE_CHECKING, Any
+
+from .location_types import get_matching_types, merge_segments
+
+logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    # Only for type-checking; not imported at runtime to keep the base package
+    # free of SQLAlchemy as a hard dependency.
+    from sqlalchemy import Engine
+
+
+def _normalize_name(name: str) -> str:
+    """Normalize a name for accent- and case-insensitive matching."""
+    nfkd = unicodedata.normalize("NFKD", name)
+    stripped = "".join(c for c in nfkd if not unicodedata.combining(c))
+    return stripped.lower().strip()
+
+
+def _require_sqlalchemy() -> Any:
+    """Import sqlalchemy, raising a clear error if it is not installed."""
+    try:
+        import sqlalchemy  # noqa: PLC0415
+
+        return sqlalchemy
+    except ImportError as exc:
+        raise ImportError(
+            "SQLAlchemy is required for PostGISDataSource. Install it with: pip install etter[postgis]"
+        ) from exc
+
+
+class PostGISDataSource:
+    """
+    Geographic data source backed by a PostGIS table.
+
+    Expects the table to follow the unified normalized schema produced by the
+    ``scripts/load_data_postgis.py`` loader:
+
+    .. code-block:: sql
+
+        CREATE TABLE <table> (
+            id      TEXT PRIMARY KEY,
+            name    TEXT NOT NULL,
+            type    TEXT,
+            geom    GEOMETRY(Geometry, 4326)
+        );
+
+    Geometries must already be in WGS84 (EPSG:4326).  If your data lives in a
+    different CRS, reproject it before storing or set ``crs`` accordingly and
+    the datasource will reproject on the fly using ``pyproj``.
+
+    Args:
+        connection: A SQLAlchemy :class:`~sqlalchemy.engine.Engine` **or** a
+            connection URL string (e.g. ``"postgresql+psycopg2://user:pass@host/db"``).
+            When a string is provided the engine is created internally.
+        table: Fully-qualified table name, e.g. ``"public.swissnames3d"``.
+        name_column: Column used for name-based search (default ``"name"``).
+        type_column: Column used for type filtering.  Pass ``None`` to disable
+            type filtering (default ``"type"``).
+        geometry_column: PostGIS geometry column (default ``"geom"``).
+        id_column: Primary-key column (default ``"id"``).
+        crs: CRS of the stored geometries as an EPSG string.  Defaults to
+            ``"EPSG:4326"`` (no reprojection).  If a different CRS is supplied
+            geometries are reprojected to WGS84 before being returned.
+        type_map: Optional mapping of raw ``type`` column values to normalized
+            type strings used by the rest of the etter package.  When ``None``
+            the stored values are used as-is.
+        fuzzy_threshold: Minimum ``pg_trgm`` similarity score (0–1) used for
+            fuzzy fallback search when no exact ``ILIKE`` match is found.
+
+    Example::
+
+        from sqlalchemy import create_engine
+        from etter.datasources import PostGISDataSource
+
+        engine = create_engine("postgresql+psycopg2://user:pass@localhost/geodata")
+        source = PostGISDataSource(engine, table="public.swissnames3d")
+        results = source.search("Lac Léman", type="lake")
+    """
+
+    def __init__(
+        self,
+        connection: str | Engine,
+        table: str,
+        name_column: str = "name",
+        type_column: str | None = "type",
+        geometry_column: str = "geom",
+        id_column: str = "id",
+        crs: str = "EPSG:4326",
+        type_map: dict[str, str] | None = None,
+        fuzzy_threshold: float = 0.3,
+    ) -> None:
+        sa = _require_sqlalchemy()
+
+        if isinstance(connection, str):
+            self._engine = sa.create_engine(connection)
+        else:
+            self._engine = connection
+
+        self._table = table
+        self._name_col = name_column
+        self._type_col = type_column
+        self._geom_col = geometry_column
+        self._id_col = id_column
+        self._crs = crs
+        self._type_map = type_map or {}
+        self._fuzzy_threshold = fuzzy_threshold
+
+        self._trgm_available: bool | None = None
+
+    def _get_connection(self) -> Any:
+        """Return a SQLAlchemy connection from the engine."""
+        return self._engine.connect()
+
+    def _check_trgm(self, conn: Any) -> bool:
+        """Return True if pg_trgm extension is available in the database."""
+        if self._trgm_available is not None:
+            return self._trgm_available
+        sa = _require_sqlalchemy()
+        try:
+            result = conn.execute(sa.text("SELECT 1 FROM pg_extension WHERE extname = 'pg_trgm'"))
+            self._trgm_available = result.fetchone() is not None
+        except Exception:
+            logger.exception("Failed to check pg_trgm availability")
+            self._trgm_available = False
+        return self._trgm_available
+
+    def _normalize_type(self, raw_type: str | None) -> str | None:
+        """Apply type_map to a raw DB value, or return it unchanged."""
+        if raw_type is None:
+            return None
+        return self._type_map.get(raw_type, raw_type)
+
+    def _row_to_feature(self, row: Any) -> dict[str, Any]:
+        """Convert a SQLAlchemy Row to a GeoJSON Feature dict."""
+        feature_id = str(row.id)
+        name = str(row.name)
+        raw_type = getattr(row, "type", None)
+        normalized_type = self._normalize_type(raw_type)
+
+        geojson_str = row.geojson
+        if geojson_str:
+            geometry = json.loads(geojson_str)
+        else:
+            geometry = {"type": "Point", "coordinates": [0, 0]}
+
+        bbox = _bbox_from_geojson(geometry)
+
+        properties: dict[str, Any] = {
+            "name": name,
+            "type": normalized_type,
+            "confidence": 1.0,
+        }
+
+        return {
+            "type": "Feature",
+            "id": feature_id,
+            "geometry": geometry,
+            "bbox": bbox,
+            "properties": properties,
+        }
+
+    def _build_select_columns(self) -> str:
+        """Build the SELECT column list as a SQL fragment."""
+        type_expr = f", {self._type_col} AS type" if self._type_col else ", NULL AS type"
+        if self._crs.upper() != "EPSG:4326":
+            geom_expr = f", ST_AsGeoJSON(ST_Transform({self._geom_col}, 4326)) AS geojson"
+        else:
+            geom_expr = f", ST_AsGeoJSON({self._geom_col}) AS geojson"
+        return f"{self._id_col} AS id, {self._name_col} AS name{type_expr}{geom_expr}"
+
+    def search(
+        self,
+        name: str,
+        type: str | None = None,
+        max_results: int = 10,
+    ) -> list[dict[str, Any]]:
+        """
+        Search for geographic features by name.
+
+        Uses a three-step cascade, stopping as soon as any step returns results:
+
+        1. **Normalized exact match**
+        2. **ILIKE substring**
+        3. **pg_trgm fuzzy** (requires the ``pg_trgm`` extension).
+
+        ``merge_segments`` is applied after all rows are fetched so that
+        multi-segment linestrings (rivers, roads) are merged before the
+        ``max_results`` cap is applied.
+
+        Args:
+            name: Location name to search for.
+            type: Optional type hint for filtering results.
+            max_results: Maximum number of results to return.
+
+        Returns:
+            List of matching GeoJSON Feature dicts in WGS84.
+        """
+        sa = _require_sqlalchemy()
+        cols = self._build_select_columns()
+
+        # Resolve type filter to concrete types via the hierarchy
+        type_filter_values: list[str] | None = None
+        if type is not None and self._type_col is not None:
+            matching_types = get_matching_types(type)
+            type_filter_values = matching_types if matching_types else [type.lower()]
+
+        # Fetch more rows than requested so that merge_segments has the full
+        # set of segments to work with.  Without this, a SQL LIMIT applied
+        # *before* merging would only return a partial set of linestring
+        # segments, producing incorrect / truncated geometries.
+        # We cap the internal limit at 2000 to avoid unbounded queries.
+        internal_limit = min(max(max_results * 20, 100), 2000)
+
+        with self._get_connection() as conn:
+            features = self._search_normalized(conn, sa, cols, name, type_filter_values, internal_limit)
+
+        if not features:
+            with self._get_connection() as conn:
+                features = self._search_ilike(conn, sa, cols, name, type_filter_values, internal_limit)
+
+        if not features:
+            with self._get_connection() as conn:
+                features = self._search_fuzzy(conn, sa, cols, name, type_filter_values, internal_limit)
+
+        features = merge_segments(features)
+        return features[:max_results]
+
+    def _type_filter_sql(self, values: list[str] | None) -> tuple[str, dict[str, Any]]:
+        """Return a WHERE clause fragment and bind params for type filtering."""
+        if not values or self._type_col is None:
+            return "", {}
+        placeholders = ", ".join(f":type_{i}" for i in range(len(values)))
+        clause = f" AND {self._type_col} IN ({placeholders})"
+        params = {f"type_{i}": v for i, v in enumerate(values)}
+        return clause, params
+
+    def _search_normalized(
+        self,
+        conn: Any,
+        sa: Any,
+        cols: str,
+        name: str,
+        type_filter: list[str] | None,
+        fetch_limit: int,
+    ) -> list[dict[str, Any]]:
+        """
+        Exact accent- and case-insensitive search.
+
+        Accent normalization (NFD decomposition + diacritic strip) is done in
+        Python before the query is sent to the DB.
+        """
+        type_clause, type_params = self._type_filter_sql(type_filter)
+        sql = sa.text(
+            f"SELECT {cols} FROM {self._table} "  # noqa: S608
+            f"WHERE lower({self._name_col}) = :query{type_clause} "
+            f"LIMIT :limit"
+        )
+        params: dict[str, Any] = {
+            "query": _normalize_name(name),
+            "limit": fetch_limit,
+            **type_params,
+        }
+        try:
+            result = conn.execute(sql, params)
+            return [self._row_to_feature(row) for row in result]
+        except Exception:
+            logger.exception("Normalized search failed for %r", name)
+            return []
+
+    def _search_ilike(
+        self,
+        conn: Any,
+        sa: Any,
+        cols: str,
+        name: str,
+        type_filter: list[str] | None,
+        fetch_limit: int,
+    ) -> list[dict[str, Any]]:
+        """Case-insensitive substring fallback using ``ILIKE '%name%'``."""
+        type_clause, type_params = self._type_filter_sql(type_filter)
+        sql = sa.text(
+            f"SELECT {cols} FROM {self._table} "  # noqa: S608
+            f"WHERE {self._name_col} ILIKE :pattern{type_clause} "
+            f"LIMIT :limit"
+        )
+        params: dict[str, Any] = {"pattern": f"%{name}%", "limit": fetch_limit, **type_params}
+        try:
+            result = conn.execute(sql, params)
+            return [self._row_to_feature(row) for row in result]
+        except Exception:
+            logger.exception("ILIKE search failed for %r", name)
+            return []
+
+    def _search_fuzzy(
+        self,
+        conn: Any,
+        sa: Any,
+        cols: str,
+        name: str,
+        type_filter: list[str] | None,
+        fetch_limit: int,
+    ) -> list[dict[str, Any]]:
+        """Fuzzy fallback using pg_trgm similarity (if extension is available)."""
+        if not self._check_trgm(conn):
+            return []
+        type_clause, type_params = self._type_filter_sql(type_filter)
+        sql = sa.text(
+            f"SELECT {cols} FROM {self._table} "  # noqa: S608
+            f"WHERE similarity({self._name_col}, :name) > :threshold{type_clause} "
+            f"ORDER BY similarity({self._name_col}, :name) DESC "
+            f"LIMIT :limit"
+        )
+        params: dict[str, Any] = {
+            "name": name,
+            "threshold": self._fuzzy_threshold,
+            "limit": fetch_limit,
+            **type_params,
+        }
+        try:
+            result = conn.execute(sql, params)
+            return [self._row_to_feature(row) for row in result]
+        except Exception:
+            logger.exception("Fuzzy search failed for %r", name)
+            return []
+
+    def get_by_id(self, feature_id: str) -> dict[str, Any] | None:
+        """
+        Get a specific feature by its unique identifier.
+
+        Args:
+            feature_id: Value of the ``id`` column.
+
+        Returns:
+            The matching GeoJSON Feature dict, or ``None`` if not found.
+        """
+        sa = _require_sqlalchemy()
+        cols = self._build_select_columns()
+        sql = sa.text(
+            f"SELECT {cols} FROM {self._table} WHERE {self._id_col} = :id LIMIT 1"  # noqa: S608
+        )
+        with self._get_connection() as conn:
+            try:
+                result = conn.execute(sql, {"id": feature_id})
+                row = result.fetchone()
+                return self._row_to_feature(row) if row else None
+            except Exception:
+                logger.exception("get_by_id failed for %r", feature_id)
+                return None
+
+    def get_available_types(self) -> list[str]:
+        """
+        Return the distinct ``type`` values present in the table.
+
+        Returns:
+            Sorted list of concrete type strings, or an empty list if the table
+            has no type column.
+        """
+        if self._type_col is None:
+            return []
+        sa = _require_sqlalchemy()
+        sql = sa.text(
+            f"SELECT DISTINCT {self._type_col} AS type FROM {self._table} "  # noqa: S608
+            f"WHERE {self._type_col} IS NOT NULL ORDER BY 1"
+        )
+        with self._get_connection() as conn:
+            try:
+                result = conn.execute(sql)
+                raw_types = [row.type for row in result]
+            except Exception:
+                logger.exception("get_available_types failed")
+                return []
+
+        normalized = {self._normalize_type(t) for t in raw_types if t}
+        return sorted(t for t in normalized if t)
+
+
+# Geometry helpers
+
+
+def _bbox_from_geojson(geometry: dict[str, Any]) -> tuple[float, float, float, float] | None:
+    """Compute a bounding-box tuple from a GeoJSON geometry dict."""
+    try:
+        coords = _flatten_coords(geometry)
+        if not coords:
+            return None
+        xs = [c[0] for c in coords]
+        ys = [c[1] for c in coords]
+        return (min(xs), min(ys), max(xs), max(ys))
+    except Exception:
+        return None
+
+
+def _flatten_coords(geometry: dict[str, Any]) -> list[list[float]]:
+    """Recursively extract all coordinate pairs from a GeoJSON geometry."""
+    geom_type = geometry.get("type", "")
+    coords = geometry.get("coordinates")
+
+    if geom_type == "Point":
+        return [coords] if coords else []
+    if geom_type in ("MultiPoint", "LineString"):
+        return list(coords) if coords else []
+    if geom_type in ("MultiLineString", "Polygon"):
+        return [pt for ring in (coords or []) for pt in ring]
+    if geom_type in ("MultiPolygon",):
+        return [pt for poly in (coords or []) for ring in poly for pt in ring]
+    if geom_type == "GeometryCollection":
+        return [pt for g in geometry.get("geometries", []) for pt in _flatten_coords(g)]
+    return []

--- a/etter/datasources/postgis.py
+++ b/etter/datasources/postgis.py
@@ -154,6 +154,12 @@ class PostGISDataSource:
         else:
             self._engine = connection
 
+        try:
+            with self._engine.connect() as conn:
+                conn.execute(sa.text(f"SELECT 1 FROM {table} LIMIT 1"))
+        except Exception as exc:
+            raise ValueError(f"Failed to connect to database or access table {table!r}") from exc
+
         self._table = table
         self._name_col = name_column
         self._type_col = type_column

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,11 +29,15 @@ dev = [
     "ruff>=0.15",
     "ty>=0.0",
     "pdoc>=14.0",
+    "fastapi>=0.135",
+    "python-dotenv>=1.2",
+    "uvicorn>=0.41",
+    "mcp[cli]>=1.26",
+    "rich>=13.0",
     # PostGIS integration tests
     "testcontainers[postgres]>=4.0",
     "psycopg2-binary>=2.9",
-    "sqlalchemy>=2.0",
-    "geoalchemy2>=0.15",
+    "etter[postgis]",
 ]
 
 [build-system]
@@ -57,16 +61,3 @@ python_files = ["test_*.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]
 
-[dependency-groups]
-dev = [
-    "fastapi>=0.135",
-    "python-dotenv>=1.2",
-    "uvicorn>=0.41",
-    "mcp[cli]>=1.26",
-    "rich>=13.0",
-    # PostGIS integration tests
-    "testcontainers[postgres]>=4.0",
-    "psycopg2-binary>=2.9",
-    "sqlalchemy>=2.0",
-    "geoalchemy2>=0.15",
-]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,10 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+postgis = [
+    "sqlalchemy>=2.0",
+    "geoalchemy2>=0.15",
+]
 dev = [
     "langchain-openai>=1.1",
     "pytest>=9.0",
@@ -25,6 +29,11 @@ dev = [
     "ruff>=0.15",
     "ty>=0.0",
     "pdoc>=14.0",
+    # PostGIS integration tests
+    "testcontainers[postgres]>=4.0",
+    "psycopg2-binary>=2.9",
+    "sqlalchemy>=2.0",
+    "geoalchemy2>=0.15",
 ]
 
 [build-system]
@@ -55,4 +64,9 @@ dev = [
     "uvicorn>=0.41",
     "mcp[cli]>=1.26",
     "rich>=13.0",
+    # PostGIS integration tests
+    "testcontainers[postgres]>=4.0",
+    "psycopg2-binary>=2.9",
+    "sqlalchemy>=2.0",
+    "geoalchemy2>=0.15",
 ]

--- a/scripts/load_data_postgis.py
+++ b/scripts/load_data_postgis.py
@@ -2,9 +2,11 @@
 """
 Load SwissNames3D and IGN BD-CARTO geodata into a PostGIS database.
 
-Instantiates the existing source classes (SwissNames3DSource, IGNBDCartoSource)
-to load and normalise data, then writes the resulting GeoDataFrame to PostGIS
-using the unified schema expected by PostGISDataSource:
+Raw dataset type values are stored as-is so that a PostGISDataSource with the
+appropriate type_map (OBJEKTART_TYPE_MAP / IGN_BDCARTO_TYPE_MAP) can translate
+them at query time.
+
+Schema written to PostGIS:
     id TEXT, name TEXT, type TEXT, geom GEOMETRY(4326)
 
 Usage::
@@ -38,8 +40,8 @@ import geopandas as gpd
 import pandas as pd
 from sqlalchemy import create_engine, text
 
-from etter.datasources.ign_bdcarto import _NAME_COL, _TYPE_COL, IGNBDCartoSource
-from etter.datasources.swissnames3d import SwissNames3DSource, _objektart_to_type
+from etter.datasources.ign_bdcarto import _LAYER_CONFIGS, _NAME_COL, _TYPE_COL, IGNBDCartoSource
+from etter.datasources.swissnames3d import SwissNames3DSource
 
 DB_URL = os.environ.get("ETTER_DB_URL")
 SWISSNAMES3D_PATH = Path(os.environ.get("SWISSNAMES3D_PATH", "data"))
@@ -69,7 +71,7 @@ def _write_to_postgis(
     schema: str,
     if_exists: Literal["fail", "replace", "append"],
 ) -> None:
-    """Write a normalised GeoDataFrame to PostGIS and rename geometry column to 'geom'."""
+    """Write a GeoDataFrame to PostGIS and rename geometry column to 'geom'."""
     gdf.to_postgis(table, engine, schema=schema, if_exists=if_exists, index=False)
     with engine.connect() as conn:
         conn.execute(text(f"ALTER TABLE {schema}.{table} RENAME COLUMN geometry TO geom"))  # noqa: S608
@@ -99,12 +101,12 @@ def load_swissnames3d(engine: Any) -> None:
 
     ids = raw[id_col].astype(str) if id_col else pd.Series([str(i) for i in range(len(raw))])
     names = raw[name_col].astype(str)
-    types = raw[type_col].apply(_objektart_to_type) if type_col else pd.Series(["unknown"] * len(raw))
+    types = raw[type_col].astype(str) if type_col else pd.Series(["unknown"] * len(raw))
 
-    normalized = gpd.GeoDataFrame({"id": ids, "name": names, "type": types}, geometry=raw.geometry, crs="EPSG:4326")
-    normalized = normalized[normalized["name"].str.strip() != ""]
+    out = gpd.GeoDataFrame({"id": ids, "name": names, "type": types}, geometry=raw.geometry, crs="EPSG:4326")
+    out = gpd.GeoDataFrame(out[out["name"].str.strip() != ""], crs="EPSG:4326")
 
-    _write_to_postgis(normalized, engine, SWISSNAMES3D_TABLE, DB_SCHEMA, IF_EXISTS)
+    _write_to_postgis(out, engine, SWISSNAMES3D_TABLE, DB_SCHEMA, IF_EXISTS)
 
 
 def load_ign_bdcarto(engine: Any) -> None:
@@ -122,17 +124,30 @@ def load_ign_bdcarto(engine: Any) -> None:
 
     print(f"  Loaded {len(raw):,} features …")
 
+    def _raw_type(row: pd.Series) -> str:
+        layer = row.get("_layer")
+        cfg = _LAYER_CONFIGS.get(layer, {}) if layer else {}
+        if cfg.get("type_map"):
+            type_col: str = cfg["type_col"]
+            val = row.get(type_col)
+            return str(val) if pd.notna(val) else "unknown"
+
+        val = row.get(_TYPE_COL)
+        return str(val) if pd.notna(val) else "unknown"
+
     id_col = "cleabs" if "cleabs" in raw.columns else None
     ids = raw[id_col].astype(str) if id_col else pd.Series([str(i) for i in range(len(raw))])
 
-    normalized = gpd.GeoDataFrame(
-        {"id": ids, "name": raw[_NAME_COL].astype(str), "type": raw[_TYPE_COL].astype(str)},
+    types = raw.apply(_raw_type, axis=1)
+
+    out = gpd.GeoDataFrame(
+        {"id": ids, "name": raw[_NAME_COL].astype(str), "type": types},
         geometry=raw.geometry,
         crs="EPSG:4326",
     )
-    normalized = normalized[normalized["name"].str.strip() != ""]
+    out = gpd.GeoDataFrame(out[out["name"].str.strip() != ""], crs="EPSG:4326")
 
-    _write_to_postgis(normalized, engine, IGN_BDCARTO_TABLE, DB_SCHEMA, IF_EXISTS)
+    _write_to_postgis(out, engine, IGN_BDCARTO_TABLE, DB_SCHEMA, IF_EXISTS)
 
 
 def main() -> None:

--- a/scripts/load_data_postgis.py
+++ b/scripts/load_data_postgis.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""
+Load SwissNames3D and IGN BD-CARTO geodata into a PostGIS database.
+
+Instantiates the existing source classes (SwissNames3DSource, IGNBDCartoSource)
+to load and normalise data, then writes the resulting GeoDataFrame to PostGIS
+using the unified schema expected by PostGISDataSource:
+    id TEXT, name TEXT, type TEXT, geom GEOMETRY(4326)
+
+Usage::
+
+    python scripts/load_data_postgis.py
+
+Environment variables:
+
+    ETTER_DB_URL          SQLAlchemy connection URL (required).
+                          e.g. postgresql+psycopg2://user:pass@host:5432/db
+    SWISSNAMES3D_PATH     Path to the SwissNames3D data directory or shapefile.
+                          Default: data/
+    IGN_BDCARTO_PATH      Path to the IGN BD-CARTO directory of .gpkg files.
+                          Default: data/bdcarto
+    SWISSNAMES3D_TABLE    Target table name for SwissNames3D.
+                          Default: swissnames3d
+    IGN_BDCARTO_TABLE     Target table name for IGN BD-CARTO.
+                          Default: ign_bdcarto
+    DB_SCHEMA             PostgreSQL schema for both tables.
+                          Default: public
+    IF_EXISTS             pandas to_postgis if_exists strategy:
+                          "replace" (default) | "append" | "fail"
+"""
+
+import os
+import sys
+from pathlib import Path
+from typing import Any, Literal
+
+import geopandas as gpd
+import pandas as pd
+from sqlalchemy import create_engine, text
+
+from etter.datasources.ign_bdcarto import _NAME_COL, _TYPE_COL, IGNBDCartoSource
+from etter.datasources.swissnames3d import SwissNames3DSource, _objektart_to_type
+
+DB_URL = os.environ.get("ETTER_DB_URL")
+SWISSNAMES3D_PATH = Path(os.environ.get("SWISSNAMES3D_PATH", "data"))
+IGN_BDCARTO_PATH = Path(os.environ.get("IGN_BDCARTO_PATH", "data/bdcarto"))
+SWISSNAMES3D_TABLE = os.environ.get("SWISSNAMES3D_TABLE", "swissnames3d")
+IGN_BDCARTO_TABLE = os.environ.get("IGN_BDCARTO_TABLE", "ign_bdcarto")
+DB_SCHEMA = os.environ.get("DB_SCHEMA", "public")
+IF_EXISTS_RAW = os.environ.get("IF_EXISTS", "replace").lower()
+if IF_EXISTS_RAW not in ("fail", "replace", "append"):
+    print(f"Invalid IF_EXISTS value: {IF_EXISTS_RAW}. Must be 'fail', 'replace', or 'append'.", file=sys.stderr)
+    sys.exit(1)
+IF_EXISTS: Literal["fail", "replace", "append"] = IF_EXISTS_RAW
+
+
+def _ensure_postgis(engine: Any) -> None:
+    """Enable PostGIS extension (idempotent)."""
+    with engine.connect() as conn:
+        conn.execute(text("CREATE EXTENSION IF NOT EXISTS postgis"))
+        conn.commit()
+    print("PostGIS extension enabled.")
+
+
+def _write_to_postgis(
+    gdf: gpd.GeoDataFrame,
+    engine: Any,
+    table: str,
+    schema: str,
+    if_exists: Literal["fail", "replace", "append"],
+) -> None:
+    """Write a normalised GeoDataFrame to PostGIS and rename geometry column to 'geom'."""
+    gdf.to_postgis(table, engine, schema=schema, if_exists=if_exists, index=False)
+    with engine.connect() as conn:
+        conn.execute(text(f"ALTER TABLE {schema}.{table} RENAME COLUMN geometry TO geom"))  # noqa: S608
+        conn.commit()
+    print(f"  Written {len(gdf):,} rows to {schema}.{table}")
+
+
+def load_swissnames3d(engine: Any) -> None:
+    """Load SwissNames3D into PostGIS by reusing SwissNames3DSource."""
+    print(f"\nLoading SwissNames3D from {SWISSNAMES3D_PATH} …")
+
+    if not SWISSNAMES3D_PATH.exists():
+        print(f"  SKIP: path not found ({SWISSNAMES3D_PATH})")
+        return
+
+    source = SwissNames3DSource(SWISSNAMES3D_PATH)
+    source._ensure_loaded()
+    raw = source._gdf
+    assert raw is not None
+
+    print(f"  Loaded {len(raw):,} features, reprojecting to EPSG:4326 …")
+    raw = raw.to_crs("EPSG:4326")
+
+    name_col = source._detect_name_column()
+    type_col = source._detect_type_column()
+    id_col = source._detect_id_column()
+
+    ids = raw[id_col].astype(str) if id_col else pd.Series([str(i) for i in range(len(raw))])
+    names = raw[name_col].astype(str)
+    types = raw[type_col].apply(_objektart_to_type) if type_col else pd.Series(["unknown"] * len(raw))
+
+    normalized = gpd.GeoDataFrame({"id": ids, "name": names, "type": types}, geometry=raw.geometry, crs="EPSG:4326")
+    normalized = normalized[normalized["name"].str.strip() != ""]
+
+    _write_to_postgis(normalized, engine, SWISSNAMES3D_TABLE, DB_SCHEMA, IF_EXISTS)
+
+
+def load_ign_bdcarto(engine: Any) -> None:
+    """Load IGN BD-CARTO into PostGIS by reusing IGNBDCartoSource."""
+    print(f"\nLoading IGN BD-CARTO from {IGN_BDCARTO_PATH} …")
+
+    if not IGN_BDCARTO_PATH.exists():
+        print(f"  SKIP: path not found ({IGN_BDCARTO_PATH})")
+        return
+
+    source = IGNBDCartoSource(IGN_BDCARTO_PATH)
+    source._ensure_loaded()
+    raw = source._gdf
+    assert raw is not None
+
+    print(f"  Loaded {len(raw):,} features …")
+
+    id_col = "cleabs" if "cleabs" in raw.columns else None
+    ids = raw[id_col].astype(str) if id_col else pd.Series([str(i) for i in range(len(raw))])
+
+    normalized = gpd.GeoDataFrame(
+        {"id": ids, "name": raw[_NAME_COL].astype(str), "type": raw[_TYPE_COL].astype(str)},
+        geometry=raw.geometry,
+        crs="EPSG:4326",
+    )
+    normalized = normalized[normalized["name"].str.strip() != ""]
+
+    _write_to_postgis(normalized, engine, IGN_BDCARTO_TABLE, DB_SCHEMA, IF_EXISTS)
+
+
+def main() -> None:
+    if not DB_URL:
+        print("ERROR: ETTER_DB_URL environment variable is required.", file=sys.stderr)
+        print(
+            "Example: export ETTER_DB_URL=postgresql+psycopg2://user:pass@localhost:5432/geodata",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    print(f"Connecting to database: {DB_URL.split('@')[-1]}")  # hide credentials in log
+    engine = create_engine(DB_URL)
+
+    _ensure_postgis(engine)
+    load_swissnames3d(engine)
+    load_ign_bdcarto(engine)
+
+    print("\nData loading complete.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_postgis_datasource.py
+++ b/tests/test_postgis_datasource.py
@@ -284,15 +284,15 @@ def test_bbox_present_for_polygon(source):
 
 
 def test_type_map_normalisation(db_engine, populated_table):  # noqa: ARG001
-    """type_map parameter remaps raw DB type values."""
+    """type_map translates raw DB type values to normalized etter types in output."""
     source = PostGISDataSource(
         connection=db_engine,
         table=TABLE_NAME,
-        type_map={"city": "settlement", "peak": "mountain_peak"},
+        type_map={"settlement": ["city"]},
     )
     results = source.search("Geneva")
     assert results
-    # After mapping, "city" should become "settlement"
+    # After mapping, raw "city" should appear as "settlement" in output.
     assert results[0]["properties"]["type"] == "settlement"
 
 
@@ -307,3 +307,99 @@ def test_no_type_column(db_engine, populated_table):  # noqa: ARG001
     assert len(results) >= 1
     types = source.get_available_types()
     assert types == []
+
+
+RAW_TABLE_NAME = "public.test_raw_types"
+
+_RAW_TYPE_MAP: dict[str, list[str]] = {
+    "lake": ["See", "Seeteil", "Stausee"],
+    "mountain": ["Berg"],
+    "peak": ["Gipfel"],
+    "river": ["Fliessgewaesser"],
+    "city": ["Ort"],
+}
+
+
+@pytest.fixture(scope="module")
+def raw_table(db_engine):
+    """Load a table with raw OBJEKTART-style type values."""
+    features = [
+        {"id": "r-001", "name": "Zürichsee", "type": "See", "geometry": Point(8.57, 47.28)},
+        {"id": "r-002", "name": "Zürich", "type": "Ort", "geometry": Point(8.54, 47.37)},
+        {"id": "r-003", "name": "Säntis", "type": "Gipfel", "geometry": Point(9.34, 47.25)},
+        {"id": "r-004", "name": "Greifensee", "type": "See", "geometry": Point(8.68, 47.37)},
+        {"id": "r-005", "name": "Limmat", "type": "Fliessgewaesser", "geometry": Point(8.54, 47.38)},
+    ]
+
+    gdf = gpd.GeoDataFrame(
+        pd.DataFrame([{k: v for k, v in f.items() if k != "geometry"} for f in features]),
+        geometry=[f["geometry"] for f in features],
+        crs="EPSG:4326",
+    )
+    gdf.to_postgis("test_raw_types", db_engine, schema="public", if_exists="replace", index=False)
+    with db_engine.connect() as conn:
+        conn.execute(text("ALTER TABLE public.test_raw_types RENAME COLUMN geometry TO geom"))
+        conn.commit()
+    yield RAW_TABLE_NAME
+
+
+@pytest.fixture(scope="module")
+def raw_source(db_engine, raw_table):  # noqa: ARG001
+    """PostGISDataSource backed by the raw-value table with a type_map."""
+    return PostGISDataSource(
+        connection=db_engine,
+        table=RAW_TABLE_NAME,
+        type_map=_RAW_TYPE_MAP,
+    )
+
+
+def test_raw_type_map_output_normalized(raw_source):
+    """Raw DB type values are translated to normalized types in returned features."""
+    results = raw_source.search("Zürichsee")
+    assert results
+    assert results[0]["properties"]["type"] == "lake"
+
+
+def test_raw_type_map_type_filter(raw_source):
+    """Searching with a normalized type hint filters against raw DB values."""
+    results = raw_source.search("see", type="lake")
+    types_in_output = {r["properties"]["type"] for r in results}
+    assert types_in_output == {"lake"}
+    # Raw values must NOT appear in output
+    raw_values = {"See", "Seeteil", "Stausee"}
+    for r in results:
+        assert r["properties"]["type"] not in raw_values
+
+
+def test_raw_type_map_category_filter(raw_source):
+    """Category type hint (e.g. 'water') expands and maps to raw DB values."""
+    # "water" category includes "lake" and "river", which map to "See"/"Seeteil"/
+    # "Stausee" and "Fliessgewaesser" in the raw table.
+    results = raw_source.search("e", type="water")
+    output_types = {r["properties"]["type"] for r in results}
+    assert output_types.issubset({"lake", "river", "pond", "spring", "waterfall", "glacier"})
+
+
+def test_raw_type_map_get_available_types(raw_source):
+    """get_available_types returns normalized type names, not raw DB values."""
+    types = raw_source.get_available_types()
+    # Should return normalized names
+    assert "lake" in types
+    assert "city" in types
+    # Raw values must not appear
+    assert "See" not in types
+    assert "Ort" not in types
+    assert "Gipfel" not in types
+
+
+def test_raw_type_map_unmapped_value(db_engine, raw_table):  # noqa: ARG001
+    """Values not present in type_map are returned as-is (passthrough)."""
+    source = PostGISDataSource(
+        connection=db_engine,
+        table=RAW_TABLE_NAME,
+        type_map={"lake": ["See"]},  # only "See" is mapped; others fall through
+    )
+    results = source.search("Säntis")
+    assert results
+    # "Gipfel" is not in the map, returned unchanged
+    assert results[0]["properties"]["type"] == "Gipfel"

--- a/tests/test_postgis_datasource.py
+++ b/tests/test_postgis_datasource.py
@@ -1,0 +1,309 @@
+"""
+Integration tests for PostGISDataSource using a real PostGIS container.
+
+Requires Docker to be available and running.  The tests are automatically
+skipped when Docker is not accessible so they don't break CI environments
+without Docker.
+
+The test suite spins up a ``postgis/postgis:18-3.6`` container, loads a
+small set of synthetic GeoJSON features into a PostGIS table via
+geopandas.to_postgis(), then exercises the full PostGISDataSource API.
+"""
+
+import shutil
+
+import pytest
+
+# Skip the whole module when Docker is unavailable, before any imports that
+# require a running daemon (testcontainers, etc.).
+
+_docker_available = shutil.which("docker") is not None
+if _docker_available:
+    try:
+        import docker as _docker_sdk
+
+        _docker_sdk.from_env().ping()
+    except Exception:
+        _docker_available = False
+
+if not _docker_available:
+    pytest.skip("Docker is not available — skipping PostGIS integration tests", allow_module_level=True)
+
+import geopandas as gpd  # noqa: E402
+import pandas as pd  # noqa: E402
+from shapely.geometry import Point, Polygon  # noqa: E402
+from sqlalchemy import create_engine, text  # noqa: E402
+from testcontainers.postgres import PostgresContainer  # noqa: E402
+
+from etter.datasources import PostGISDataSource  # noqa: E402
+
+# Shared PostGIS container fixture (module-scoped for speed)
+
+
+POSTGIS_IMAGE = "postgis/postgis:18-3.6"
+TABLE_NAME = "public.test_locations"
+
+
+@pytest.fixture(scope="module")
+def postgis_container():
+    """Start a PostGIS container for the entire test module."""
+    with PostgresContainer(
+        image=POSTGIS_IMAGE,
+        username="testuser",
+        password="testpass",
+        dbname="testdb",
+    ) as container:
+        yield container
+
+
+@pytest.fixture(scope="module")
+def db_engine(postgis_container):
+    """Create a SQLAlchemy engine connected to the test container."""
+    url = postgis_container.get_connection_url()
+    engine = create_engine(url)
+
+    # Enable PostGIS extension
+    with engine.connect() as conn:
+        conn.execute(text("CREATE EXTENSION IF NOT EXISTS postgis"))
+        conn.commit()
+
+    yield engine
+    engine.dispose()
+
+
+@pytest.fixture(scope="module")
+def populated_table(db_engine):
+    """Load synthetic test data into the PostGIS table."""
+    features = [
+        {
+            "id": "feat-001",
+            "name": "Lac Léman",
+            "type": "lake",
+            "geometry": Polygon([(6.1, 46.2), (6.9, 46.2), (6.9, 46.5), (6.1, 46.5), (6.1, 46.2)]),
+        },
+        {
+            "id": "feat-002",
+            "name": "Geneva",
+            "type": "city",
+            "geometry": Point(6.1432, 46.2044),
+        },
+        {
+            "id": "feat-003",
+            "name": "Mont Blanc",
+            "type": "peak",
+            "geometry": Point(6.8651, 45.8326),
+        },
+        {
+            "id": "feat-004",
+            "name": "Rhône",
+            "type": "river",
+            "geometry": Point(7.3, 46.0),
+        },
+        {
+            "id": "feat-005",
+            "name": "La Venoge",
+            "type": "river",
+            "geometry": Point(6.5, 46.5),
+        },
+        {
+            "id": "feat-006",
+            "name": "Zurich",
+            "type": "city",
+            "geometry": Point(8.5417, 47.3769),
+        },
+    ]
+
+    gdf = gpd.GeoDataFrame(
+        pd.DataFrame([{k: v for k, v in f.items() if k != "geometry"} for f in features]),
+        geometry=[f["geometry"] for f in features],
+        crs="EPSG:4326",
+    )
+
+    gdf.to_postgis(
+        "test_locations",
+        db_engine,
+        schema="public",
+        if_exists="replace",
+        index=False,
+    )
+
+    # Rename geometry column to 'geom' to match PostGISDataSource default
+    with db_engine.connect() as conn:
+        conn.execute(text("ALTER TABLE public.test_locations RENAME COLUMN geometry TO geom"))
+        conn.commit()
+
+    yield TABLE_NAME
+
+
+@pytest.fixture(scope="module")
+def source(db_engine, populated_table):  # noqa: ARG001
+    """Create a PostGISDataSource instance backed by the test container."""
+    return PostGISDataSource(
+        connection=db_engine,
+        table=TABLE_NAME,
+        name_column="name",
+        type_column="type",
+        geometry_column="geom",
+        id_column="id",
+    )
+
+
+def test_search_exact(source):
+    """Exact name returns the expected feature."""
+    results = source.search("Geneva")
+    assert len(results) >= 1
+    names = [r["properties"]["name"] for r in results]
+    assert "Geneva" in names
+
+
+def test_search_case_insensitive(source):
+    """ILIKE search is case-insensitive."""
+    results = source.search("geneva")
+    assert any(r["properties"]["name"] == "Geneva" for r in results)
+
+
+def test_search_partial_name(source):
+    """Partial name match (substring) returns results."""
+    results = source.search("Léman")
+    assert len(results) >= 1
+    assert any("Léman" in r["properties"]["name"] for r in results)
+
+
+def test_search_with_type_filter(source):
+    """Type filter restricts results to matching types."""
+    results = source.search("Geneva", type="city")
+    assert all(r["properties"]["type"] == "city" for r in results)
+
+
+def test_search_type_category_expansion(source):
+    """Type category 'water' expands to include 'lake' and 'river'."""
+    results = source.search("Lac", type="water")
+    types = {r["properties"]["type"] for r in results}
+    # All returned types should be water-related
+    water_types = {"lake", "river", "pond", "spring", "waterfall", "glacier"}
+    assert types.issubset(water_types)
+
+
+def test_search_no_results(source):
+    """Unknown name returns empty list."""
+    results = source.search("zzznomatch999")
+    assert results == []
+
+
+def test_search_max_results(source):
+    """max_results limits the number of returned features."""
+    results = source.search("e", max_results=2)
+    assert len(results) <= 2
+
+
+def test_get_by_id_found(source):
+    """get_by_id returns the correct feature for a known id."""
+    feature = source.get_by_id("feat-002")
+    assert feature is not None
+    assert feature["id"] == "feat-002"
+    assert feature["properties"]["name"] == "Geneva"
+    assert feature["properties"]["type"] == "city"
+
+
+def test_get_by_id_not_found(source):
+    """get_by_id returns None for an unknown id."""
+    result = source.get_by_id("does-not-exist-99999")
+    assert result is None
+
+
+def test_geojson_structure(source):
+    """Returned features conform to GeoJSON Feature structure."""
+    results = source.search("Zurich")
+    assert len(results) >= 1
+    feature = results[0]
+    assert feature["type"] == "Feature"
+    assert "id" in feature
+    assert "geometry" in feature
+    assert "properties" in feature
+    geometry = feature["geometry"]
+    assert "type" in geometry
+    assert "coordinates" in geometry
+
+
+def test_coordinates_in_wgs84(source):
+    """Returned coordinates are in WGS84 range."""
+    results = source.search("Geneva")
+    assert results
+    coords = results[0]["geometry"]["coordinates"]
+    lon, lat = coords[0], coords[1]
+    assert -180 <= lon <= 180
+    assert -90 <= lat <= 90
+
+
+def test_get_available_types(source):
+    """get_available_types returns the distinct types in the table."""
+    types = source.get_available_types()
+    assert isinstance(types, list)
+    assert len(types) > 0
+    assert "city" in types
+    assert "lake" in types
+    assert "river" in types
+    assert "peak" in types
+
+
+def test_get_available_types_sorted(source):
+    """get_available_types returns types in sorted order."""
+    types = source.get_available_types()
+    assert types == sorted(types)
+
+
+def test_connection_string_creates_engine(postgis_container):
+    """Passing a connection string creates an engine internally."""
+    url = postgis_container.get_connection_url()
+    source = PostGISDataSource(
+        connection=url,
+        table=TABLE_NAME,
+    )
+    # Should be able to call get_available_types without error
+    types = source.get_available_types()
+    assert isinstance(types, list)
+
+
+def test_confidence_in_properties(source):
+    """Returned features have a 'confidence' property."""
+    results = source.search("Geneva")
+    assert results
+    assert results[0]["properties"]["confidence"] == 1.0
+
+
+def test_bbox_present_for_polygon(source):
+    """Polygon features include a bbox."""
+    results = source.search("Léman", type="lake")
+    if not results:
+        results = source.search("Lac Léman")
+    assert results
+    feature = results[0]
+    if feature["geometry"]["type"] == "Polygon":
+        assert feature["bbox"] is not None
+        assert len(feature["bbox"]) == 4
+
+
+def test_type_map_normalisation(db_engine, populated_table):  # noqa: ARG001
+    """type_map parameter remaps raw DB type values."""
+    source = PostGISDataSource(
+        connection=db_engine,
+        table=TABLE_NAME,
+        type_map={"city": "settlement", "peak": "mountain_peak"},
+    )
+    results = source.search("Geneva")
+    assert results
+    # After mapping, "city" should become "settlement"
+    assert results[0]["properties"]["type"] == "settlement"
+
+
+def test_no_type_column(db_engine, populated_table):  # noqa: ARG001
+    """Datasource works when type_column is None."""
+    source = PostGISDataSource(
+        connection=db_engine,
+        table=TABLE_NAME,
+        type_column=None,
+    )
+    results = source.search("Geneva")
+    assert len(results) >= 1
+    types = source.get_available_types()
+    assert types == []

--- a/uv.lock
+++ b/uv.lock
@@ -470,70 +470,53 @@ dependencies = [
 
 [package.optional-dependencies]
 dev = [
+    { name = "fastapi" },
     { name = "geoalchemy2" },
     { name = "langchain-openai" },
+    { name = "mcp", extra = ["cli"] },
     { name = "pdoc" },
     { name = "psycopg2-binary" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "python-dotenv" },
+    { name = "rich" },
     { name = "ruff" },
     { name = "sqlalchemy" },
     { name = "testcontainers" },
     { name = "ty" },
+    { name = "uvicorn" },
 ]
 postgis = [
     { name = "geoalchemy2" },
     { name = "sqlalchemy" },
 ]
 
-[package.dev-dependencies]
-dev = [
-    { name = "fastapi" },
-    { name = "geoalchemy2" },
-    { name = "mcp", extra = ["cli"] },
-    { name = "psycopg2-binary" },
-    { name = "python-dotenv" },
-    { name = "rich" },
-    { name = "sqlalchemy" },
-    { name = "testcontainers" },
-    { name = "uvicorn" },
-]
-
 [package.metadata]
 requires-dist = [
-    { name = "geoalchemy2", marker = "extra == 'dev'", specifier = ">=0.15" },
+    { name = "etter", extras = ["postgis"], marker = "extra == 'dev'" },
+    { name = "fastapi", marker = "extra == 'dev'", specifier = ">=0.135" },
     { name = "geoalchemy2", marker = "extra == 'postgis'", specifier = ">=0.15" },
     { name = "geopandas", specifier = ">=1.1" },
     { name = "langchain", specifier = ">=1.2" },
     { name = "langchain-openai", marker = "extra == 'dev'", specifier = ">=1.1" },
+    { name = "mcp", extras = ["cli"], marker = "extra == 'dev'", specifier = ">=1.26" },
     { name = "pdoc", marker = "extra == 'dev'", specifier = ">=14.0" },
     { name = "psycopg2-binary", marker = "extra == 'dev'", specifier = ">=2.9" },
     { name = "pydantic", specifier = ">=2.12" },
     { name = "pyproj", specifier = ">=3.7" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=7.0" },
+    { name = "python-dotenv", marker = "extra == 'dev'", specifier = ">=1.2" },
     { name = "rapidfuzz", specifier = ">=3.14" },
+    { name = "rich", marker = "extra == 'dev'", specifier = ">=13.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.15" },
     { name = "shapely", specifier = ">=2.1" },
-    { name = "sqlalchemy", marker = "extra == 'dev'", specifier = ">=2.0" },
     { name = "sqlalchemy", marker = "extra == 'postgis'", specifier = ">=2.0" },
     { name = "testcontainers", extras = ["postgres"], marker = "extra == 'dev'", specifier = ">=4.0" },
     { name = "ty", marker = "extra == 'dev'", specifier = ">=0.0" },
+    { name = "uvicorn", marker = "extra == 'dev'", specifier = ">=0.41" },
 ]
 provides-extras = ["postgis", "dev"]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "fastapi", specifier = ">=0.135" },
-    { name = "geoalchemy2", specifier = ">=0.15" },
-    { name = "mcp", extras = ["cli"], specifier = ">=1.26" },
-    { name = "psycopg2-binary", specifier = ">=2.9" },
-    { name = "python-dotenv", specifier = ">=1.2" },
-    { name = "rich", specifier = ">=13.0" },
-    { name = "sqlalchemy", specifier = ">=2.0" },
-    { name = "testcontainers", extras = ["postgres"], specifier = ">=4.0" },
-    { name = "uvicorn", specifier = ">=0.41" },
-]
 
 [[package]]
 name = "exceptiongroup"

--- a/uv.lock
+++ b/uv.lock
@@ -441,6 +441,20 @@ wheels = [
 ]
 
 [[package]]
+name = "docker"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "requests" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/91/9b/4a2ea29aeba62471211598dac5d96825bb49348fa07e906ea930394a83ce/docker-7.1.0.tar.gz", hash = "sha256:ad8c70e6e3f8926cb8a92619b832b4ea5299e2831c14284663184e200546fa6c", size = 117834, upload-time = "2024-05-23T11:13:57.216Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/26/57c6fb270950d476074c087527a558ccb6f4436657314bfb6cdf484114c4/docker-7.1.0-py3-none-any.whl", hash = "sha256:c96b93b7f0a746f9e77d325bcfb87422a3d8bd4f03136ae8a85b37f1898d5fc0", size = 147774, upload-time = "2024-05-23T11:13:55.01Z" },
+]
+
+[[package]]
 name = "etter"
 version = "0.1.0"
 source = { editable = "." }
@@ -456,29 +470,44 @@ dependencies = [
 
 [package.optional-dependencies]
 dev = [
+    { name = "geoalchemy2" },
     { name = "langchain-openai" },
     { name = "pdoc" },
+    { name = "psycopg2-binary" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "ruff" },
+    { name = "sqlalchemy" },
+    { name = "testcontainers" },
     { name = "ty" },
+]
+postgis = [
+    { name = "geoalchemy2" },
+    { name = "sqlalchemy" },
 ]
 
 [package.dev-dependencies]
 dev = [
     { name = "fastapi" },
+    { name = "geoalchemy2" },
     { name = "mcp", extra = ["cli"] },
+    { name = "psycopg2-binary" },
     { name = "python-dotenv" },
     { name = "rich" },
+    { name = "sqlalchemy" },
+    { name = "testcontainers" },
     { name = "uvicorn" },
 ]
 
 [package.metadata]
 requires-dist = [
+    { name = "geoalchemy2", marker = "extra == 'dev'", specifier = ">=0.15" },
+    { name = "geoalchemy2", marker = "extra == 'postgis'", specifier = ">=0.15" },
     { name = "geopandas", specifier = ">=1.1" },
     { name = "langchain", specifier = ">=1.2" },
     { name = "langchain-openai", marker = "extra == 'dev'", specifier = ">=1.1" },
     { name = "pdoc", marker = "extra == 'dev'", specifier = ">=14.0" },
+    { name = "psycopg2-binary", marker = "extra == 'dev'", specifier = ">=2.9" },
     { name = "pydantic", specifier = ">=2.12" },
     { name = "pyproj", specifier = ">=3.7" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0" },
@@ -486,16 +515,23 @@ requires-dist = [
     { name = "rapidfuzz", specifier = ">=3.14" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.15" },
     { name = "shapely", specifier = ">=2.1" },
+    { name = "sqlalchemy", marker = "extra == 'dev'", specifier = ">=2.0" },
+    { name = "sqlalchemy", marker = "extra == 'postgis'", specifier = ">=2.0" },
+    { name = "testcontainers", extras = ["postgres"], marker = "extra == 'dev'", specifier = ">=4.0" },
     { name = "ty", marker = "extra == 'dev'", specifier = ">=0.0" },
 ]
-provides-extras = ["dev"]
+provides-extras = ["postgis", "dev"]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "fastapi", specifier = ">=0.135" },
+    { name = "geoalchemy2", specifier = ">=0.15" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.26" },
+    { name = "psycopg2-binary", specifier = ">=2.9" },
     { name = "python-dotenv", specifier = ">=1.2" },
     { name = "rich", specifier = ">=13.0" },
+    { name = "sqlalchemy", specifier = ">=2.0" },
+    { name = "testcontainers", extras = ["postgres"], specifier = ">=4.0" },
     { name = "uvicorn", specifier = ">=0.41" },
 ]
 
@@ -528,6 +564,19 @@ wheels = [
 ]
 
 [[package]]
+name = "geoalchemy2"
+version = "0.18.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+    { name = "sqlalchemy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ec/9d/02d54b0d61a2f331044ea7b4216ee1c98a8ad3a69906dfc3967c51501623/geoalchemy2-0.18.4.tar.gz", hash = "sha256:5719e2bb040d5c406d5d03425fec87997ce9351843b053ca11373a0f5a31971b", size = 239766, upload-time = "2026-03-02T14:48:48.43Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/56/92/60ee150773376aa9b542dcd44660e4ae9f5f14e690c8795be476156de598/geoalchemy2-0.18.4-py3-none-any.whl", hash = "sha256:89e6680dcbb6b8d8c784dcaa889e48ab2783aa42487ee5730fdbd7a7c7ddf6ec", size = 81097, upload-time = "2026-03-02T14:48:47.456Z" },
+]
+
+[[package]]
 name = "geopandas"
 version = "1.1.3"
 source = { registry = "https://pypi.org/simple" }
@@ -545,6 +594,66 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/85/ba/8e6b2091878e99e86a36a814dcaeff652ed48bdb03d53e78e15aaa63a914/geopandas-1.1.3.tar.gz", hash = "sha256:91a31989b6f566012838d21d5f8033f37dce882079ccb7cfdc40d5ccce7f284f", size = 336718, upload-time = "2026-03-09T21:49:09.545Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3c/78/6a04792ace63a93e162f1305392d500ae8ddcb620e7eb88a22fd622b35bb/geopandas-1.1.3-py3-none-any.whl", hash = "sha256:90d62a64f95eaa3be2ccc115c5f3d6e24208bb11983b390fdc0621a3eccd0230", size = 342514, upload-time = "2026-03-09T21:49:07.973Z" },
+]
+
+[[package]]
+name = "greenlet"
+version = "3.3.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/51/1664f6b78fc6ebbd98019a1fd730e83fa78f2db7058f72b1463d3612b8db/greenlet-3.3.2.tar.gz", hash = "sha256:2eaf067fc6d886931c7962e8c6bede15d2f01965560f3359b27c80bde2d151f2", size = 188267, upload-time = "2026-02-20T20:54:15.531Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/3f/9859f655d11901e7b2996c6e3d33e0caa9a1d4572c3bc61ed0faa64b2f4c/greenlet-3.3.2-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:9bc885b89709d901859cf95179ec9f6bb67a3d2bb1f0e88456461bd4b7f8fd0d", size = 277747, upload-time = "2026-02-20T20:16:21.325Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/07/cb284a8b5c6498dbd7cba35d31380bb123d7dceaa7907f606c8ff5993cbf/greenlet-3.3.2-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b568183cf65b94919be4438dc28416b234b678c608cafac8874dfeeb2a9bbe13", size = 579202, upload-time = "2026-02-20T20:47:28.955Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/45/67922992b3a152f726163b19f890a85129a992f39607a2a53155de3448b8/greenlet-3.3.2-cp310-cp310-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:527fec58dc9f90efd594b9b700662ed3fb2493c2122067ac9c740d98080a620e", size = 590620, upload-time = "2026-02-20T20:55:55.581Z" },
+    { url = "https://files.pythonhosted.org/packages/03/5f/6e2a7d80c353587751ef3d44bb947f0565ec008a2e0927821c007e96d3a7/greenlet-3.3.2-cp310-cp310-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:508c7f01f1791fbc8e011bd508f6794cb95397fdb198a46cb6635eb5b78d85a7", size = 602132, upload-time = "2026-02-20T21:02:43.261Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/55/9f1ebb5a825215fadcc0f7d5073f6e79e3007e3282b14b22d6aba7ca6cb8/greenlet-3.3.2-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ad0c8917dd42a819fe77e6bdfcb84e3379c0de956469301d9fd36427a1ca501f", size = 591729, upload-time = "2026-02-20T20:20:58.395Z" },
+    { url = "https://files.pythonhosted.org/packages/24/b4/21f5455773d37f94b866eb3cf5caed88d6cea6dd2c6e1f9c34f463cba3ec/greenlet-3.3.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:97245cc10e5515dbc8c3104b2928f7f02b6813002770cfaffaf9a6e0fc2b94ef", size = 1551946, upload-time = "2026-02-20T20:49:31.102Z" },
+    { url = "https://files.pythonhosted.org/packages/00/68/91f061a926abead128fe1a87f0b453ccf07368666bd59ffa46016627a930/greenlet-3.3.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:8c1fdd7d1b309ff0da81d60a9688a8bd044ac4e18b250320a96fc68d31c209ca", size = 1618494, upload-time = "2026-02-20T20:21:06.541Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/78/f93e840cbaef8becaf6adafbaf1319682a6c2d8c1c20224267a5c6c8c891/greenlet-3.3.2-cp310-cp310-win_amd64.whl", hash = "sha256:5d0e35379f93a6d0222de929a25ab47b5eb35b5ef4721c2b9cbcc4036129ff1f", size = 230092, upload-time = "2026-02-20T20:17:09.379Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/47/16400cb42d18d7a6bb46f0626852c1718612e35dcb0dffa16bbaffdf5dd2/greenlet-3.3.2-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:c56692189a7d1c7606cb794be0a8381470d95c57ce5be03fb3d0ef57c7853b86", size = 278890, upload-time = "2026-02-20T20:19:39.263Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/90/42762b77a5b6aa96cd8c0e80612663d39211e8ae8a6cd47c7f1249a66262/greenlet-3.3.2-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1ebd458fa8285960f382841da585e02201b53a5ec2bac6b156fc623b5ce4499f", size = 581120, upload-time = "2026-02-20T20:47:30.161Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/6f/f3d64f4fa0a9c7b5c5b3c810ff1df614540d5aa7d519261b53fba55d4df9/greenlet-3.3.2-cp311-cp311-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a443358b33c4ec7b05b79a7c8b466f5d275025e750298be7340f8fc63dff2a55", size = 594363, upload-time = "2026-02-20T20:55:56.965Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/8b/1430a04657735a3f23116c2e0d5eb10220928846e4537a938a41b350bed6/greenlet-3.3.2-cp311-cp311-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4375a58e49522698d3e70cc0b801c19433021b5c37686f7ce9c65b0d5c8677d2", size = 605046, upload-time = "2026-02-20T21:02:45.234Z" },
+    { url = "https://files.pythonhosted.org/packages/72/83/3e06a52aca8128bdd4dcd67e932b809e76a96ab8c232a8b025b2850264c5/greenlet-3.3.2-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8e2cd90d413acbf5e77ae41e5d3c9b3ac1d011a756d7284d7f3f2b806bbd6358", size = 594156, upload-time = "2026-02-20T20:20:59.955Z" },
+    { url = "https://files.pythonhosted.org/packages/70/79/0de5e62b873e08fe3cef7dbe84e5c4bc0e8ed0c7ff131bccb8405cd107c8/greenlet-3.3.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:442b6057453c8cb29b4fb36a2ac689382fc71112273726e2423f7f17dc73bf99", size = 1554649, upload-time = "2026-02-20T20:49:32.293Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/00/32d30dee8389dc36d42170a9c66217757289e2afb0de59a3565260f38373/greenlet-3.3.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:45abe8eb6339518180d5a7fa47fa01945414d7cca5ecb745346fc6a87d2750be", size = 1619472, upload-time = "2026-02-20T20:21:07.966Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/3a/efb2cf697fbccdf75b24e2c18025e7dfa54c4f31fab75c51d0fe79942cef/greenlet-3.3.2-cp311-cp311-win_amd64.whl", hash = "sha256:1e692b2dae4cc7077cbb11b47d258533b48c8fde69a33d0d8a82e2fe8d8531d5", size = 230389, upload-time = "2026-02-20T20:17:18.772Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/a1/65bbc059a43a7e2143ec4fc1f9e3f673e04f9c7b371a494a101422ac4fd5/greenlet-3.3.2-cp311-cp311-win_arm64.whl", hash = "sha256:02b0a8682aecd4d3c6c18edf52bc8e51eacdd75c8eac52a790a210b06aa295fd", size = 229645, upload-time = "2026-02-20T20:18:18.695Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/ab/1608e5a7578e62113506740b88066bf09888322a311cff602105e619bd87/greenlet-3.3.2-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:ac8d61d4343b799d1e526db579833d72f23759c71e07181c2d2944e429eb09cd", size = 280358, upload-time = "2026-02-20T20:17:43.971Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/23/0eae412a4ade4e6623ff7626e38998cb9b11e9ff1ebacaa021e4e108ec15/greenlet-3.3.2-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3ceec72030dae6ac0c8ed7591b96b70410a8be370b6a477b1dbc072856ad02bd", size = 601217, upload-time = "2026-02-20T20:47:31.462Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/16/5b1678a9c07098ecb9ab2dd159fafaf12e963293e61ee8d10ecb55273e5e/greenlet-3.3.2-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a2a5be83a45ce6188c045bcc44b0ee037d6a518978de9a5d97438548b953a1ac", size = 611792, upload-time = "2026-02-20T20:55:58.423Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/c5/cc09412a29e43406eba18d61c70baa936e299bc27e074e2be3806ed29098/greenlet-3.3.2-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ae9e21c84035c490506c17002f5c8ab25f980205c3e61ddb3a2a2a2e6c411fcb", size = 626250, upload-time = "2026-02-20T21:02:46.596Z" },
+    { url = "https://files.pythonhosted.org/packages/50/1f/5155f55bd71cabd03765a4aac9ac446be129895271f73872c36ebd4b04b6/greenlet-3.3.2-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:43e99d1749147ac21dde49b99c9abffcbc1e2d55c67501465ef0930d6e78e070", size = 613875, upload-time = "2026-02-20T20:21:01.102Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/dd/845f249c3fcd69e32df80cdab059b4be8b766ef5830a3d0aa9d6cad55beb/greenlet-3.3.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:4c956a19350e2c37f2c48b336a3afb4bff120b36076d9d7fb68cb44e05d95b79", size = 1571467, upload-time = "2026-02-20T20:49:33.495Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/50/2649fe21fcc2b56659a452868e695634722a6655ba245d9f77f5656010bf/greenlet-3.3.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6c6f8ba97d17a1e7d664151284cb3315fc5f8353e75221ed4324f84eb162b395", size = 1640001, upload-time = "2026-02-20T20:21:09.154Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/40/cc802e067d02af8b60b6771cea7d57e21ef5e6659912814babb42b864713/greenlet-3.3.2-cp312-cp312-win_amd64.whl", hash = "sha256:34308836d8370bddadb41f5a7ce96879b72e2fdfb4e87729330c6ab52376409f", size = 231081, upload-time = "2026-02-20T20:17:28.121Z" },
+    { url = "https://files.pythonhosted.org/packages/58/2e/fe7f36ff1982d6b10a60d5e0740c759259a7d6d2e1dc41da6d96de32fff6/greenlet-3.3.2-cp312-cp312-win_arm64.whl", hash = "sha256:d3a62fa76a32b462a97198e4c9e99afb9ab375115e74e9a83ce180e7a496f643", size = 230331, upload-time = "2026-02-20T20:17:23.34Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/48/f8b875fa7dea7dd9b33245e37f065af59df6a25af2f9561efa8d822fde51/greenlet-3.3.2-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:aa6ac98bdfd716a749b84d4034486863fd81c3abde9aa3cf8eff9127981a4ae4", size = 279120, upload-time = "2026-02-20T20:19:01.9Z" },
+    { url = "https://files.pythonhosted.org/packages/49/8d/9771d03e7a8b1ee456511961e1b97a6d77ae1dea4a34a5b98eee706689d3/greenlet-3.3.2-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ab0c7e7901a00bc0a7284907273dc165b32e0d109a6713babd04471327ff7986", size = 603238, upload-time = "2026-02-20T20:47:32.873Z" },
+    { url = "https://files.pythonhosted.org/packages/59/0e/4223c2bbb63cd5c97f28ffb2a8aee71bdfb30b323c35d409450f51b91e3e/greenlet-3.3.2-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d248d8c23c67d2291ffd47af766e2a3aa9fa1c6703155c099feb11f526c63a92", size = 614219, upload-time = "2026-02-20T20:55:59.817Z" },
+    { url = "https://files.pythonhosted.org/packages/94/2b/4d012a69759ac9d77210b8bfb128bc621125f5b20fc398bce3940d036b1c/greenlet-3.3.2-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ccd21bb86944ca9be6d967cf7691e658e43417782bce90b5d2faeda0ff78a7dd", size = 628268, upload-time = "2026-02-20T21:02:48.024Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/34/259b28ea7a2a0c904b11cd36c79b8cef8019b26ee5dbe24e73b469dea347/greenlet-3.3.2-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b6997d360a4e6a4e936c0f9625b1c20416b8a0ea18a8e19cabbefc712e7397ab", size = 616774, upload-time = "2026-02-20T20:21:02.454Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/03/996c2d1689d486a6e199cb0f1cf9e4aa940c500e01bdf201299d7d61fa69/greenlet-3.3.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:64970c33a50551c7c50491671265d8954046cb6e8e2999aacdd60e439b70418a", size = 1571277, upload-time = "2026-02-20T20:49:34.795Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/c4/2570fc07f34a39f2caf0bf9f24b0a1a0a47bc2e8e465b2c2424821389dfc/greenlet-3.3.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1a9172f5bf6bd88e6ba5a84e0a68afeac9dc7b6b412b245dd64f52d83c81e55b", size = 1640455, upload-time = "2026-02-20T20:21:10.261Z" },
+    { url = "https://files.pythonhosted.org/packages/91/39/5ef5aa23bc545aa0d31e1b9b55822b32c8da93ba657295840b6b34124009/greenlet-3.3.2-cp313-cp313-win_amd64.whl", hash = "sha256:a7945dd0eab63ded0a48e4dcade82939783c172290a7903ebde9e184333ca124", size = 230961, upload-time = "2026-02-20T20:16:58.461Z" },
+    { url = "https://files.pythonhosted.org/packages/62/6b/a89f8456dcb06becff288f563618e9f20deed8dd29beea14f9a168aef64b/greenlet-3.3.2-cp313-cp313-win_arm64.whl", hash = "sha256:394ead29063ee3515b4e775216cb756b2e3b4a7e55ae8fd884f17fa579e6b327", size = 230221, upload-time = "2026-02-20T20:17:37.152Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/ae/8bffcbd373b57a5992cd077cbe8858fff39110480a9d50697091faea6f39/greenlet-3.3.2-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:8d1658d7291f9859beed69a776c10822a0a799bc4bfe1bd4272bb60e62507dab", size = 279650, upload-time = "2026-02-20T20:18:00.783Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/c0/45f93f348fa49abf32ac8439938726c480bd96b2a3c6f4d949ec0124b69f/greenlet-3.3.2-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:18cb1b7337bca281915b3c5d5ae19f4e76d35e1df80f4ad3c1a7be91fadf1082", size = 650295, upload-time = "2026-02-20T20:47:34.036Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/de/dd7589b3f2b8372069ab3e4763ea5329940fc7ad9dcd3e272a37516d7c9b/greenlet-3.3.2-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c2e47408e8ce1c6f1ceea0dffcdf6ebb85cc09e55c7af407c99f1112016e45e9", size = 662163, upload-time = "2026-02-20T20:56:01.295Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/ac/85804f74f1ccea31ba518dcc8ee6f14c79f73fe36fa1beba38930806df09/greenlet-3.3.2-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:e3cb43ce200f59483eb82949bf1835a99cf43d7571e900d7c8d5c62cdf25d2f9", size = 675371, upload-time = "2026-02-20T21:02:49.664Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/d8/09bfa816572a4d83bccd6750df1926f79158b1c36c5f73786e26dbe4ee38/greenlet-3.3.2-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:63d10328839d1973e5ba35e98cccbca71b232b14051fd957b6f8b6e8e80d0506", size = 664160, upload-time = "2026-02-20T20:21:04.015Z" },
+    { url = "https://files.pythonhosted.org/packages/48/cf/56832f0c8255d27f6c35d41b5ec91168d74ec721d85f01a12131eec6b93c/greenlet-3.3.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:8e4ab3cfb02993c8cc248ea73d7dae6cec0253e9afa311c9b37e603ca9fad2ce", size = 1619181, upload-time = "2026-02-20T20:49:36.052Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/23/b90b60a4aabb4cec0796e55f25ffbfb579a907c3898cd2905c8918acaa16/greenlet-3.3.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:94ad81f0fd3c0c0681a018a976e5c2bd2ca2d9d94895f23e7bb1af4e8af4e2d5", size = 1687713, upload-time = "2026-02-20T20:21:11.684Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/ca/2101ca3d9223a1dc125140dbc063644dca76df6ff356531eb27bc267b446/greenlet-3.3.2-cp314-cp314-win_amd64.whl", hash = "sha256:8c4dd0f3997cf2512f7601563cc90dfb8957c0cff1e3a1b23991d4ea1776c492", size = 232034, upload-time = "2026-02-20T20:20:08.186Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/4a/ecf894e962a59dea60f04877eea0fd5724618da89f1867b28ee8b91e811f/greenlet-3.3.2-cp314-cp314-win_arm64.whl", hash = "sha256:cd6f9e2bbd46321ba3bbb4c8a15794d32960e3b0ae2cc4d49a1a53d314805d71", size = 231437, upload-time = "2026-02-20T20:18:59.722Z" },
+    { url = "https://files.pythonhosted.org/packages/98/6d/8f2ef704e614bcf58ed43cfb8d87afa1c285e98194ab2cfad351bf04f81e/greenlet-3.3.2-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:e26e72bec7ab387ac80caa7496e0f908ff954f31065b0ffc1f8ecb1338b11b54", size = 286617, upload-time = "2026-02-20T20:19:29.856Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/0d/93894161d307c6ea237a43988f27eba0947b360b99ac5239ad3fe09f0b47/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8b466dff7a4ffda6ca975979bab80bdadde979e29fc947ac3be4451428d8b0e4", size = 655189, upload-time = "2026-02-20T20:47:35.742Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/2c/d2d506ebd8abcb57386ec4f7ba20f4030cbe56eae541bc6fd6ef399c0b41/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b8bddc5b73c9720bea487b3bffdb1840fe4e3656fba3bd40aa1489e9f37877ff", size = 658225, upload-time = "2026-02-20T20:56:02.527Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/67/8197b7e7e602150938049d8e7f30de1660cfb87e4c8ee349b42b67bdb2e1/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:59b3e2c40f6706b05a9cd299c836c6aa2378cabe25d021acd80f13abf81181cf", size = 666581, upload-time = "2026-02-20T21:02:51.526Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/30/3a09155fbf728673a1dea713572d2d31159f824a37c22da82127056c44e4/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b26b0f4428b871a751968285a1ac9648944cea09807177ac639b030bddebcea4", size = 657907, upload-time = "2026-02-20T20:21:05.259Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/fd/d05a4b7acd0154ed758797f0a43b4c0962a843bedfe980115e842c5b2d08/greenlet-3.3.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:1fb39a11ee2e4d94be9a76671482be9398560955c9e568550de0224e41104727", size = 1618857, upload-time = "2026-02-20T20:49:37.309Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/e1/50ee92a5db521de8f35075b5eff060dd43d39ebd46c2181a2042f7070385/greenlet-3.3.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:20154044d9085151bc309e7689d6f7ba10027f8f5a8c0676ad398b951913d89e", size = 1680010, upload-time = "2026-02-20T20:21:13.427Z" },
+    { url = "https://files.pythonhosted.org/packages/29/4b/45d90626aef8e65336bed690106d1382f7a43665e2249017e9527df8823b/greenlet-3.3.2-cp314-cp314t-win_amd64.whl", hash = "sha256:c04c5e06ec3e022cbfe2cd4a846e1d4e50087444f875ff6d2c2ad8445495cf1a", size = 237086, upload-time = "2026-02-20T20:20:45.786Z" },
 ]
 
 [[package]]
@@ -1508,6 +1617,69 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "psycopg2-binary"
+version = "2.9.11"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ac/6c/8767aaa597ba424643dc87348c6f1754dd9f48e80fdc1b9f7ca5c3a7c213/psycopg2-binary-2.9.11.tar.gz", hash = "sha256:b6aed9e096bf63f9e75edf2581aa9a7e7186d97ab5c177aa6c87797cd591236c", size = 379620, upload-time = "2025-10-10T11:14:48.041Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/f2/8e377d29c2ecf99f6062d35ea606b036e8800720eccfec5fe3dd672c2b24/psycopg2_binary-2.9.11-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d6fe6b47d0b42ce1c9f1fa3e35bb365011ca22e39db37074458f27921dca40f2", size = 3756506, upload-time = "2025-10-10T11:10:30.144Z" },
+    { url = "https://files.pythonhosted.org/packages/24/cc/dc143ea88e4ec9d386106cac05023b69668bd0be20794c613446eaefafe5/psycopg2_binary-2.9.11-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:a6c0e4262e089516603a09474ee13eabf09cb65c332277e39af68f6233911087", size = 3863943, upload-time = "2025-10-10T11:10:34.586Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/df/16848771155e7c419c60afeb24950b8aaa3ab09c0a091ec3ccca26a574d0/psycopg2_binary-2.9.11-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c47676e5b485393f069b4d7a811267d3168ce46f988fa602658b8bb901e9e64d", size = 4410873, upload-time = "2025-10-10T11:10:38.951Z" },
+    { url = "https://files.pythonhosted.org/packages/43/79/5ef5f32621abd5a541b89b04231fe959a9b327c874a1d41156041c75494b/psycopg2_binary-2.9.11-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:a28d8c01a7b27a1e3265b11250ba7557e5f72b5ee9e5f3a2fa8d2949c29bf5d2", size = 4468016, upload-time = "2025-10-10T11:10:43.319Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/9b/d7542d0f7ad78f57385971f426704776d7b310f5219ed58da5d605b1892e/psycopg2_binary-2.9.11-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5f3f2732cf504a1aa9e9609d02f79bea1067d99edf844ab92c247bbca143303b", size = 4164996, upload-time = "2025-10-10T11:10:46.705Z" },
+    { url = "https://files.pythonhosted.org/packages/14/ed/e409388b537fa7414330687936917c522f6a77a13474e4238219fcfd9a84/psycopg2_binary-2.9.11-cp310-cp310-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:865f9945ed1b3950d968ec4690ce68c55019d79e4497366d36e090327ce7db14", size = 3981881, upload-time = "2025-10-30T02:54:57.182Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/30/50e330e63bb05efc6fa7c1447df3e08954894025ca3dcb396ecc6739bc26/psycopg2_binary-2.9.11-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:91537a8df2bde69b1c1db01d6d944c831ca793952e4f57892600e96cee95f2cd", size = 3650857, upload-time = "2025-10-10T11:10:50.112Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/e0/4026e4c12bb49dd028756c5b0bc4c572319f2d8f1c9008e0dad8cc9addd7/psycopg2_binary-2.9.11-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:4dca1f356a67ecb68c81a7bc7809f1569ad9e152ce7fd02c2f2036862ca9f66b", size = 3296063, upload-time = "2025-10-10T11:10:54.089Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/34/eb172be293c886fef5299fe5c3fcf180a05478be89856067881007934a7c/psycopg2_binary-2.9.11-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:0da4de5c1ac69d94ed4364b6cbe7190c1a70d325f112ba783d83f8440285f152", size = 3043464, upload-time = "2025-10-30T02:55:02.483Z" },
+    { url = "https://files.pythonhosted.org/packages/18/1c/532c5d2cb11986372f14b798a95f2eaafe5779334f6a80589a68b5fcf769/psycopg2_binary-2.9.11-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:37d8412565a7267f7d79e29ab66876e55cb5e8e7b3bbf94f8206f6795f8f7e7e", size = 3345378, upload-time = "2025-10-10T11:11:01.039Z" },
+    { url = "https://files.pythonhosted.org/packages/70/e7/de420e1cf16f838e1fa17b1120e83afff374c7c0130d088dba6286fcf8ea/psycopg2_binary-2.9.11-cp310-cp310-win_amd64.whl", hash = "sha256:c665f01ec8ab273a61c62beeb8cce3014c214429ced8a308ca1fc410ecac3a39", size = 2713904, upload-time = "2025-10-10T11:11:04.81Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/ae/8d8266f6dd183ab4d48b95b9674034e1b482a3f8619b33a0d86438694577/psycopg2_binary-2.9.11-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:0e8480afd62362d0a6a27dd09e4ca2def6fa50ed3a4e7c09165266106b2ffa10", size = 3756452, upload-time = "2025-10-10T11:11:11.583Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/34/aa03d327739c1be70e09d01182619aca8ebab5970cd0cfa50dd8b9cec2ac/psycopg2_binary-2.9.11-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:763c93ef1df3da6d1a90f86ea7f3f806dc06b21c198fa87c3c25504abec9404a", size = 3863957, upload-time = "2025-10-10T11:11:16.932Z" },
+    { url = "https://files.pythonhosted.org/packages/48/89/3fdb5902bdab8868bbedc1c6e6023a4e08112ceac5db97fc2012060e0c9a/psycopg2_binary-2.9.11-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2e164359396576a3cc701ba8af4751ae68a07235d7a380c631184a611220d9a4", size = 4410955, upload-time = "2025-10-10T11:11:21.21Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/24/e18339c407a13c72b336e0d9013fbbbde77b6fd13e853979019a1269519c/psycopg2_binary-2.9.11-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:d57c9c387660b8893093459738b6abddbb30a7eab058b77b0d0d1c7d521ddfd7", size = 4468007, upload-time = "2025-10-10T11:11:24.831Z" },
+    { url = "https://files.pythonhosted.org/packages/91/7e/b8441e831a0f16c159b5381698f9f7f7ed54b77d57bc9c5f99144cc78232/psycopg2_binary-2.9.11-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2c226ef95eb2250974bf6fa7a842082b31f68385c4f3268370e3f3870e7859ee", size = 4165012, upload-time = "2025-10-10T11:11:29.51Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/61/4aa89eeb6d751f05178a13da95516c036e27468c5d4d2509bb1e15341c81/psycopg2_binary-2.9.11-cp311-cp311-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a311f1edc9967723d3511ea7d2708e2c3592e3405677bf53d5c7246753591fbb", size = 3981881, upload-time = "2025-10-30T02:55:07.332Z" },
+    { url = "https://files.pythonhosted.org/packages/76/a1/2f5841cae4c635a9459fe7aca8ed771336e9383b6429e05c01267b0774cf/psycopg2_binary-2.9.11-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:ebb415404821b6d1c47353ebe9c8645967a5235e6d88f914147e7fd411419e6f", size = 3650985, upload-time = "2025-10-10T11:11:34.975Z" },
+    { url = "https://files.pythonhosted.org/packages/84/74/4defcac9d002bca5709951b975173c8c2fa968e1a95dc713f61b3a8d3b6a/psycopg2_binary-2.9.11-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:f07c9c4a5093258a03b28fab9b4f151aa376989e7f35f855088234e656ee6a94", size = 3296039, upload-time = "2025-10-10T11:11:40.432Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/c2/782a3c64403d8ce35b5c50e1b684412cf94f171dc18111be8c976abd2de1/psycopg2_binary-2.9.11-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:00ce1830d971f43b667abe4a56e42c1e2d594b32da4802e44a73bacacb25535f", size = 3043477, upload-time = "2025-10-30T02:55:11.182Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/31/36a1d8e702aa35c38fc117c2b8be3f182613faa25d794b8aeaab948d4c03/psycopg2_binary-2.9.11-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:cffe9d7697ae7456649617e8bb8d7a45afb71cd13f7ab22af3e5c61f04840908", size = 3345842, upload-time = "2025-10-10T11:11:45.366Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/b4/a5375cda5b54cb95ee9b836930fea30ae5a8f14aa97da7821722323d979b/psycopg2_binary-2.9.11-cp311-cp311-win_amd64.whl", hash = "sha256:304fd7b7f97eef30e91b8f7e720b3db75fee010b520e434ea35ed1ff22501d03", size = 2713894, upload-time = "2025-10-10T11:11:48.775Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/91/f870a02f51be4a65987b45a7de4c2e1897dd0d01051e2b559a38fa634e3e/psycopg2_binary-2.9.11-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:be9b840ac0525a283a96b556616f5b4820e0526addb8dcf6525a0fa162730be4", size = 3756603, upload-time = "2025-10-10T11:11:52.213Z" },
+    { url = "https://files.pythonhosted.org/packages/27/fa/cae40e06849b6c9a95eb5c04d419942f00d9eaac8d81626107461e268821/psycopg2_binary-2.9.11-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f090b7ddd13ca842ebfe301cd587a76a4cf0913b1e429eb92c1be5dbeb1a19bc", size = 3864509, upload-time = "2025-10-10T11:11:56.452Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/75/364847b879eb630b3ac8293798e380e441a957c53657995053c5ec39a316/psycopg2_binary-2.9.11-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ab8905b5dcb05bf3fb22e0cf90e10f469563486ffb6a96569e51f897c750a76a", size = 4411159, upload-time = "2025-10-10T11:12:00.49Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/a0/567f7ea38b6e1c62aafd58375665a547c00c608a471620c0edc364733e13/psycopg2_binary-2.9.11-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:bf940cd7e7fec19181fdbc29d76911741153d51cab52e5c21165f3262125685e", size = 4468234, upload-time = "2025-10-10T11:12:04.892Z" },
+    { url = "https://files.pythonhosted.org/packages/30/da/4e42788fb811bbbfd7b7f045570c062f49e350e1d1f3df056c3fb5763353/psycopg2_binary-2.9.11-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fa0f693d3c68ae925966f0b14b8edda71696608039f4ed61b1fe9ffa468d16db", size = 4166236, upload-time = "2025-10-10T11:12:11.674Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/94/c1777c355bc560992af848d98216148be5f1be001af06e06fc49cbded578/psycopg2_binary-2.9.11-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a1cf393f1cdaf6a9b57c0a719a1068ba1069f022a59b8b1fe44b006745b59757", size = 3983083, upload-time = "2025-10-30T02:55:15.73Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/42/c9a21edf0e3daa7825ed04a4a8588686c6c14904344344a039556d78aa58/psycopg2_binary-2.9.11-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:ef7a6beb4beaa62f88592ccc65df20328029d721db309cb3250b0aae0fa146c3", size = 3652281, upload-time = "2025-10-10T11:12:17.713Z" },
+    { url = "https://files.pythonhosted.org/packages/12/22/dedfbcfa97917982301496b6b5e5e6c5531d1f35dd2b488b08d1ebc52482/psycopg2_binary-2.9.11-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:31b32c457a6025e74d233957cc9736742ac5a6cb196c6b68499f6bb51390bd6a", size = 3298010, upload-time = "2025-10-10T11:12:22.671Z" },
+    { url = "https://files.pythonhosted.org/packages/66/ea/d3390e6696276078bd01b2ece417deac954dfdd552d2edc3d03204416c0c/psycopg2_binary-2.9.11-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:edcb3aeb11cb4bf13a2af3c53a15b3d612edeb6409047ea0b5d6a21a9d744b34", size = 3044641, upload-time = "2025-10-30T02:55:19.929Z" },
+    { url = "https://files.pythonhosted.org/packages/12/9a/0402ded6cbd321da0c0ba7d34dc12b29b14f5764c2fc10750daa38e825fc/psycopg2_binary-2.9.11-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:62b6d93d7c0b61a1dd6197d208ab613eb7dcfdcca0a49c42ceb082257991de9d", size = 3347940, upload-time = "2025-10-10T11:12:26.529Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/d2/99b55e85832ccde77b211738ff3925a5d73ad183c0b37bcbbe5a8ff04978/psycopg2_binary-2.9.11-cp312-cp312-win_amd64.whl", hash = "sha256:b33fabeb1fde21180479b2d4667e994de7bbf0eec22832ba5d9b5e4cf65b6c6d", size = 2714147, upload-time = "2025-10-10T11:12:29.535Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/a8/a2709681b3ac11b0b1786def10006b8995125ba268c9a54bea6f5ae8bd3e/psycopg2_binary-2.9.11-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:b8fb3db325435d34235b044b199e56cdf9ff41223a4b9752e8576465170bb38c", size = 3756572, upload-time = "2025-10-10T11:12:32.873Z" },
+    { url = "https://files.pythonhosted.org/packages/62/e1/c2b38d256d0dafd32713e9f31982a5b028f4a3651f446be70785f484f472/psycopg2_binary-2.9.11-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:366df99e710a2acd90efed3764bb1e28df6c675d33a7fb40df9b7281694432ee", size = 3864529, upload-time = "2025-10-10T11:12:36.791Z" },
+    { url = "https://files.pythonhosted.org/packages/11/32/b2ffe8f3853c181e88f0a157c5fb4e383102238d73c52ac6d93a5c8bffe6/psycopg2_binary-2.9.11-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8c55b385daa2f92cb64b12ec4536c66954ac53654c7f15a203578da4e78105c0", size = 4411242, upload-time = "2025-10-10T11:12:42.388Z" },
+    { url = "https://files.pythonhosted.org/packages/10/04/6ca7477e6160ae258dc96f67c371157776564679aefd247b66f4661501a2/psycopg2_binary-2.9.11-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:c0377174bf1dd416993d16edc15357f6eb17ac998244cca19bc67cdc0e2e5766", size = 4468258, upload-time = "2025-10-10T11:12:48.654Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/7e/6a1a38f86412df101435809f225d57c1a021307dd0689f7a5e7fe83588b1/psycopg2_binary-2.9.11-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5c6ff3335ce08c75afaed19e08699e8aacf95d4a260b495a4a8545244fe2ceb3", size = 4166295, upload-time = "2025-10-10T11:12:52.525Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/7d/c07374c501b45f3579a9eb761cbf2604ddef3d96ad48679112c2c5aa9c25/psycopg2_binary-2.9.11-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:84011ba3109e06ac412f95399b704d3d6950e386b7994475b231cf61eec2fc1f", size = 3983133, upload-time = "2025-10-30T02:55:24.329Z" },
+    { url = "https://files.pythonhosted.org/packages/82/56/993b7104cb8345ad7d4516538ccf8f0d0ac640b1ebd8c754a7b024e76878/psycopg2_binary-2.9.11-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ba34475ceb08cccbdd98f6b46916917ae6eeb92b5ae111df10b544c3a4621dc4", size = 3652383, upload-time = "2025-10-10T11:12:56.387Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/ac/eaeb6029362fd8d454a27374d84c6866c82c33bfc24587b4face5a8e43ef/psycopg2_binary-2.9.11-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:b31e90fdd0f968c2de3b26ab014314fe814225b6c324f770952f7d38abf17e3c", size = 3298168, upload-time = "2025-10-10T11:13:00.403Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/39/50c3facc66bded9ada5cbc0de867499a703dc6bca6be03070b4e3b65da6c/psycopg2_binary-2.9.11-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:d526864e0f67f74937a8fce859bd56c979f5e2ec57ca7c627f5f1071ef7fee60", size = 3044712, upload-time = "2025-10-30T02:55:27.975Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/8e/b7de019a1f562f72ada81081a12823d3c1590bedc48d7d2559410a2763fe/psycopg2_binary-2.9.11-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:04195548662fa544626c8ea0f06561eb6203f1984ba5b4562764fbeb4c3d14b1", size = 3347549, upload-time = "2025-10-10T11:13:03.971Z" },
+    { url = "https://files.pythonhosted.org/packages/80/2d/1bb683f64737bbb1f86c82b7359db1eb2be4e2c0c13b947f80efefa7d3e5/psycopg2_binary-2.9.11-cp313-cp313-win_amd64.whl", hash = "sha256:efff12b432179443f54e230fdf60de1f6cc726b6c832db8701227d089310e8aa", size = 2714215, upload-time = "2025-10-10T11:13:07.14Z" },
+    { url = "https://files.pythonhosted.org/packages/64/12/93ef0098590cf51d9732b4f139533732565704f45bdc1ffa741b7c95fb54/psycopg2_binary-2.9.11-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:92e3b669236327083a2e33ccfa0d320dd01b9803b3e14dd986a4fc54aa00f4e1", size = 3756567, upload-time = "2025-10-10T11:13:11.885Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/a9/9d55c614a891288f15ca4b5209b09f0f01e3124056924e17b81b9fa054cc/psycopg2_binary-2.9.11-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:e0deeb03da539fa3577fcb0b3f2554a97f7e5477c246098dbb18091a4a01c16f", size = 3864755, upload-time = "2025-10-10T11:13:17.727Z" },
+    { url = "https://files.pythonhosted.org/packages/13/1e/98874ce72fd29cbde93209977b196a2edae03f8490d1bd8158e7f1daf3a0/psycopg2_binary-2.9.11-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:9b52a3f9bb540a3e4ec0f6ba6d31339727b2950c9772850d6545b7eae0b9d7c5", size = 4411646, upload-time = "2025-10-10T11:13:24.432Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/bd/a335ce6645334fb8d758cc358810defca14a1d19ffbc8a10bd38a2328565/psycopg2_binary-2.9.11-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:db4fd476874ccfdbb630a54426964959e58da4c61c9feba73e6094d51303d7d8", size = 4468701, upload-time = "2025-10-10T11:13:29.266Z" },
+    { url = "https://files.pythonhosted.org/packages/44/d6/c8b4f53f34e295e45709b7568bf9b9407a612ea30387d35eb9fa84f269b4/psycopg2_binary-2.9.11-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:47f212c1d3be608a12937cc131bd85502954398aaa1320cb4c14421a0ffccf4c", size = 4166293, upload-time = "2025-10-10T11:13:33.336Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/e0/f8cc36eadd1b716ab36bb290618a3292e009867e5c97ce4aba908cb99644/psycopg2_binary-2.9.11-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e35b7abae2b0adab776add56111df1735ccc71406e56203515e228a8dc07089f", size = 3983184, upload-time = "2025-10-30T02:55:32.483Z" },
+    { url = "https://files.pythonhosted.org/packages/53/3e/2a8fe18a4e61cfb3417da67b6318e12691772c0696d79434184a511906dc/psycopg2_binary-2.9.11-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:fcf21be3ce5f5659daefd2b3b3b6e4727b028221ddc94e6c1523425579664747", size = 3652650, upload-time = "2025-10-10T11:13:38.181Z" },
+    { url = "https://files.pythonhosted.org/packages/76/36/03801461b31b29fe58d228c24388f999fe814dfc302856e0d17f97d7c54d/psycopg2_binary-2.9.11-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:9bd81e64e8de111237737b29d68039b9c813bdf520156af36d26819c9a979e5f", size = 3298663, upload-time = "2025-10-10T11:13:44.878Z" },
+    { url = "https://files.pythonhosted.org/packages/97/77/21b0ea2e1a73aa5fa9222b2a6b8ba325c43c3a8d54272839c991f2345656/psycopg2_binary-2.9.11-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:32770a4d666fbdafab017086655bcddab791d7cb260a16679cc5a7338b64343b", size = 3044737, upload-time = "2025-10-30T02:55:35.69Z" },
+    { url = "https://files.pythonhosted.org/packages/67/69/f36abe5f118c1dca6d3726ceae164b9356985805480731ac6712a63f24f0/psycopg2_binary-2.9.11-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:c3cb3a676873d7506825221045bd70e0427c905b9c8ee8d6acd70cfcbd6e576d", size = 3347643, upload-time = "2025-10-10T11:13:53.499Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/36/9c0c326fe3a4227953dfb29f5d0c8ae3b8eb8c1cd2967aa569f50cb3c61f/psycopg2_binary-2.9.11-cp314-cp314-win_amd64.whl", hash = "sha256:4012c9c954dfaccd28f94e84ab9f94e12df76b4afb22331b1f0d3154893a6316", size = 2803913, upload-time = "2025-10-10T11:13:57.058Z" },
 ]
 
 [[package]]
@@ -2529,6 +2701,66 @@ wheels = [
 ]
 
 [[package]]
+name = "sqlalchemy"
+version = "2.0.48"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "greenlet", marker = "platform_machine == 'AMD64' or platform_machine == 'WIN32' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'ppc64le' or platform_machine == 'win32' or platform_machine == 'x86_64'" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1f/73/b4a9737255583b5fa858e0bb8e116eb94b88c910164ed2ed719147bde3de/sqlalchemy-2.0.48.tar.gz", hash = "sha256:5ca74f37f3369b45e1f6b7b06afb182af1fd5dde009e4ffd831830d98cbe5fe7", size = 9886075, upload-time = "2026-03-02T15:28:51.474Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/67/1235676e93dd3b742a4a8eddfae49eea46c85e3eed29f0da446a8dd57500/sqlalchemy-2.0.48-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:7001dc9d5f6bb4deb756d5928eaefe1930f6f4179da3924cbd95ee0e9f4dce89", size = 2157384, upload-time = "2026-03-02T15:38:26.781Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/d7/fa728b856daa18c10e1390e76f26f64ac890c947008284387451d56ca3d0/sqlalchemy-2.0.48-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1a89ce07ad2d4b8cfc30bd5889ec40613e028ed80ef47da7d9dd2ce969ad30e0", size = 3236981, upload-time = "2026-03-02T15:58:53.53Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/ad/6c4395649a212a6c603a72c5b9ab5dce3135a1546cfdffa3c427e71fd535/sqlalchemy-2.0.48-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:10853a53a4a00417a00913d270dddda75815fcb80675874285f41051c094d7dd", size = 3235232, upload-time = "2026-03-02T15:52:25.654Z" },
+    { url = "https://files.pythonhosted.org/packages/01/f4/58f845e511ac0509765a6f85eb24924c1ef0d54fb50de9d15b28c3601458/sqlalchemy-2.0.48-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:fac0fa4e4f55f118fd87177dacb1c6522fe39c28d498d259014020fec9164c29", size = 3188106, upload-time = "2026-03-02T15:58:55.193Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/f9/6dcc7bfa5f5794c3a095e78cd1de8269dfb5584dfd4c2c00a50d3c1ade44/sqlalchemy-2.0.48-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:3713e21ea67bca727eecd4a24bf68bcd414c403faae4989442be60994301ded0", size = 3209522, upload-time = "2026-03-02T15:52:27.407Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/5a/b632875ab35874d42657f079529f0745410604645c269a8c21fb4272ff7a/sqlalchemy-2.0.48-cp310-cp310-win32.whl", hash = "sha256:d404dc897ce10e565d647795861762aa2d06ca3f4a728c5e9a835096c7059018", size = 2117695, upload-time = "2026-03-02T15:46:51.389Z" },
+    { url = "https://files.pythonhosted.org/packages/de/03/9752eb2a41afdd8568e41ac3c3128e32a0a73eada5ab80483083604a56d1/sqlalchemy-2.0.48-cp310-cp310-win_amd64.whl", hash = "sha256:841a94c66577661c1f088ac958cd767d7c9bf507698f45afffe7a4017049de76", size = 2140928, upload-time = "2026-03-02T15:46:52.992Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/6d/b8b78b5b80f3c3ab3f7fa90faa195ec3401f6d884b60221260fd4d51864c/sqlalchemy-2.0.48-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1b4c575df7368b3b13e0cebf01d4679f9a28ed2ae6c1cd0b1d5beffb6b2007dc", size = 2157184, upload-time = "2026-03-02T15:38:28.161Z" },
+    { url = "https://files.pythonhosted.org/packages/21/4b/4f3d4a43743ab58b95b9ddf5580a265b593d017693df9e08bd55780af5bb/sqlalchemy-2.0.48-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e83e3f959aaa1c9df95c22c528096d94848a1bc819f5d0ebf7ee3df0ca63db6c", size = 3313555, upload-time = "2026-03-02T15:58:57.21Z" },
+    { url = "https://files.pythonhosted.org/packages/21/dd/3b7c53f1dbbf736fd27041aee68f8ac52226b610f914085b1652c2323442/sqlalchemy-2.0.48-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6f7b7243850edd0b8b97043f04748f31de50cf426e939def5c16bedb540698f7", size = 3313057, upload-time = "2026-03-02T15:52:29.366Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/cc/3e600a90ae64047f33313d7d32e5ad025417f09d2ded487e8284b5e21a15/sqlalchemy-2.0.48-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:82745b03b4043e04600a6b665cb98697c4339b24e34d74b0a2ac0a2488b6f94d", size = 3265431, upload-time = "2026-03-02T15:58:59.096Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/19/780138dacfe3f5024f4cf96e4005e91edf6653d53d3673be4844578faf1d/sqlalchemy-2.0.48-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:e5e088bf43f6ee6fec7dbf1ef7ff7774a616c236b5c0cb3e00662dd71a56b571", size = 3287646, upload-time = "2026-03-02T15:52:31.569Z" },
+    { url = "https://files.pythonhosted.org/packages/40/fd/f32ced124f01a23151f4777e4c705f3a470adc7bd241d9f36a7c941a33bf/sqlalchemy-2.0.48-cp311-cp311-win32.whl", hash = "sha256:9c7d0a77e36b5f4b01ca398482230ab792061d243d715299b44a0b55c89fe617", size = 2116956, upload-time = "2026-03-02T15:46:54.535Z" },
+    { url = "https://files.pythonhosted.org/packages/58/d5/dd767277f6feef12d05651538f280277e661698f617fa4d086cce6055416/sqlalchemy-2.0.48-cp311-cp311-win_amd64.whl", hash = "sha256:583849c743e0e3c9bb7446f5b5addeacedc168d657a69b418063dfdb2d90081c", size = 2141627, upload-time = "2026-03-02T15:46:55.849Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/91/a42ae716f8925e9659df2da21ba941f158686856107a61cc97a95e7647a3/sqlalchemy-2.0.48-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:348174f228b99f33ca1f773e85510e08927620caa59ffe7803b37170df30332b", size = 2155737, upload-time = "2026-03-02T15:49:13.207Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/52/f75f516a1f3888f027c1cfb5d22d4376f4b46236f2e8669dcb0cddc60275/sqlalchemy-2.0.48-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:53667b5f668991e279d21f94ccfa6e45b4e3f4500e7591ae59a8012d0f010dcb", size = 3337020, upload-time = "2026-03-02T15:50:34.547Z" },
+    { url = "https://files.pythonhosted.org/packages/37/9a/0c28b6371e0cdcb14f8f1930778cb3123acfcbd2c95bb9cf6b4a2ba0cce3/sqlalchemy-2.0.48-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:34634e196f620c7a61d18d5cf7dc841ca6daa7961aed75d532b7e58b309ac894", size = 3349983, upload-time = "2026-03-02T15:53:25.542Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/46/0aee8f3ff20b1dcbceb46ca2d87fcc3d48b407925a383ff668218509d132/sqlalchemy-2.0.48-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:546572a1793cc35857a2ffa1fe0e58571af1779bcc1ffa7c9fb0839885ed69a9", size = 3279690, upload-time = "2026-03-02T15:50:36.277Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/8c/a957bc91293b49181350bfd55e6dfc6e30b7f7d83dc6792d72043274a390/sqlalchemy-2.0.48-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:07edba08061bc277bfdc772dd2a1a43978f5a45994dd3ede26391b405c15221e", size = 3314738, upload-time = "2026-03-02T15:53:27.519Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/44/1d257d9f9556661e7bdc83667cc414ba210acfc110c82938cb3611eea58f/sqlalchemy-2.0.48-cp312-cp312-win32.whl", hash = "sha256:908a3fa6908716f803b86896a09a2c4dde5f5ce2bb07aacc71ffebb57986ce99", size = 2115546, upload-time = "2026-03-02T15:54:31.591Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/af/c3c7e1f3a2b383155a16454df62ae8c62a30dd238e42e68c24cebebbfae6/sqlalchemy-2.0.48-cp312-cp312-win_amd64.whl", hash = "sha256:68549c403f79a8e25984376480959975212a670405e3913830614432b5daa07a", size = 2142484, upload-time = "2026-03-02T15:54:34.072Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/c6/569dc8bf3cd375abc5907e82235923e986799f301cd79a903f784b996fca/sqlalchemy-2.0.48-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e3070c03701037aa418b55d36532ecb8f8446ed0135acb71c678dbdf12f5b6e4", size = 2152599, upload-time = "2026-03-02T15:49:14.41Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/ff/f4e04a4bd5a24304f38cb0d4aa2ad4c0fb34999f8b884c656535e1b2b74c/sqlalchemy-2.0.48-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2645b7d8a738763b664a12a1542c89c940daa55196e8d73e55b169cc5c99f65f", size = 3278825, upload-time = "2026-03-02T15:50:38.269Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/88/cb59509e4668d8001818d7355d9995be90c321313078c912420603a7cb95/sqlalchemy-2.0.48-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b19151e76620a412c2ac1c6f977ab1b9fa7ad43140178345136456d5265b32ed", size = 3295200, upload-time = "2026-03-02T15:53:29.366Z" },
+    { url = "https://files.pythonhosted.org/packages/87/dc/1609a4442aefd750ea2f32629559394ec92e89ac1d621a7f462b70f736ff/sqlalchemy-2.0.48-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5b193a7e29fd9fa56e502920dca47dffe60f97c863494946bd698c6058a55658", size = 3226876, upload-time = "2026-03-02T15:50:39.802Z" },
+    { url = "https://files.pythonhosted.org/packages/37/c3/6ae2ab5ea2fa989fbac4e674de01224b7a9d744becaf59bb967d62e99bed/sqlalchemy-2.0.48-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:36ac4ddc3d33e852da9cb00ffb08cea62ca05c39711dc67062ca2bb1fae35fd8", size = 3265045, upload-time = "2026-03-02T15:53:31.421Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/82/ea4665d1bb98c50c19666e672f21b81356bd6077c4574e3d2bbb84541f53/sqlalchemy-2.0.48-cp313-cp313-win32.whl", hash = "sha256:389b984139278f97757ea9b08993e7b9d1142912e046ab7d82b3fbaeb0209131", size = 2113700, upload-time = "2026-03-02T15:54:35.825Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/2b/b9040bec58c58225f073f5b0c1870defe1940835549dafec680cbd58c3c3/sqlalchemy-2.0.48-cp313-cp313-win_amd64.whl", hash = "sha256:d612c976cbc2d17edfcc4c006874b764e85e990c29ce9bd411f926bbfb02b9a2", size = 2139487, upload-time = "2026-03-02T15:54:37.079Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/7b17bd50244b78a49d22cc63c969d71dc4de54567dc152a9b46f6fae40ce/sqlalchemy-2.0.48-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:69f5bc24904d3bc3640961cddd2523e361257ef68585d6e364166dfbe8c78fae", size = 3558851, upload-time = "2026-03-02T15:57:48.607Z" },
+    { url = "https://files.pythonhosted.org/packages/20/0d/213668e9aca61d370f7d2a6449ea4ec699747fac67d4bda1bb3d129025be/sqlalchemy-2.0.48-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fd08b90d211c086181caed76931ecfa2bdfc83eea3cfccdb0f82abc6c4b876cb", size = 3525525, upload-time = "2026-03-02T16:04:38.058Z" },
+    { url = "https://files.pythonhosted.org/packages/85/d7/a84edf412979e7d59c69b89a5871f90a49228360594680e667cb2c46a828/sqlalchemy-2.0.48-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:1ccd42229aaac2df431562117ac7e667d702e8e44afdb6cf0e50fa3f18160f0b", size = 3466611, upload-time = "2026-03-02T15:57:50.759Z" },
+    { url = "https://files.pythonhosted.org/packages/86/55/42404ce5770f6be26a2b0607e7866c31b9a4176c819e9a7a5e0a055770be/sqlalchemy-2.0.48-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:f0dcbc588cd5b725162c076eb9119342f6579c7f7f55057bb7e3c6ff27e13121", size = 3475812, upload-time = "2026-03-02T16:04:40.092Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/ae/29b87775fadc43e627cf582fe3bda4d02e300f6b8f2747c764950d13784c/sqlalchemy-2.0.48-cp313-cp313t-win32.whl", hash = "sha256:9764014ef5e58aab76220c5664abb5d47d5bc858d9debf821e55cfdd0f128485", size = 2141335, upload-time = "2026-03-02T15:52:51.518Z" },
+    { url = "https://files.pythonhosted.org/packages/91/44/f39d063c90f2443e5b46ec4819abd3d8de653893aae92df42a5c4f5843de/sqlalchemy-2.0.48-cp313-cp313t-win_amd64.whl", hash = "sha256:e2f35b4cccd9ed286ad62e0a3c3ac21e06c02abc60e20aa51a3e305a30f5fa79", size = 2173095, upload-time = "2026-03-02T15:52:52.79Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/b3/f437eaa1cf028bb3c927172c7272366393e73ccd104dcf5b6963f4ab5318/sqlalchemy-2.0.48-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:e2d0d88686e3d35a76f3e15a34e8c12d73fc94c1dea1cd55782e695cc14086dd", size = 2154401, upload-time = "2026-03-02T15:49:17.24Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/1c/b3abdf0f402aa3f60f0df6ea53d92a162b458fca2321d8f1f00278506402/sqlalchemy-2.0.48-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:49b7bddc1eebf011ea5ab722fdbe67a401caa34a350d278cc7733c0e88fecb1f", size = 3274528, upload-time = "2026-03-02T15:50:41.489Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/5e/327428a034407651a048f5e624361adf3f9fbac9d0fa98e981e9c6ff2f5e/sqlalchemy-2.0.48-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:426c5ca86415d9b8945c7073597e10de9644802e2ff502b8e1f11a7a2642856b", size = 3279523, upload-time = "2026-03-02T15:53:32.962Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/ca/ece73c81a918add0965b76b868b7b5359e068380b90ef1656ee995940c02/sqlalchemy-2.0.48-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:288937433bd44e3990e7da2402fabc44a3c6c25d3704da066b85b89a85474ae0", size = 3224312, upload-time = "2026-03-02T15:50:42.996Z" },
+    { url = "https://files.pythonhosted.org/packages/88/11/fbaf1ae91fa4ee43f4fe79661cead6358644824419c26adb004941bdce7c/sqlalchemy-2.0.48-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:8183dc57ae7d9edc1346e007e840a9f3d6aa7b7f165203a99e16f447150140d2", size = 3246304, upload-time = "2026-03-02T15:53:34.937Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/a8/5fb0deb13930b4f2f698c5541ae076c18981173e27dd00376dbaea7a9c82/sqlalchemy-2.0.48-cp314-cp314-win32.whl", hash = "sha256:1182437cb2d97988cfea04cf6cdc0b0bb9c74f4d56ec3d08b81e23d621a28cc6", size = 2116565, upload-time = "2026-03-02T15:54:38.321Z" },
+    { url = "https://files.pythonhosted.org/packages/95/7e/e83615cb63f80047f18e61e31e8e32257d39458426c23006deeaf48f463b/sqlalchemy-2.0.48-cp314-cp314-win_amd64.whl", hash = "sha256:144921da96c08feb9e2b052c5c5c1d0d151a292c6135623c6b2c041f2a45f9e0", size = 2142205, upload-time = "2026-03-02T15:54:39.831Z" },
+    { url = "https://files.pythonhosted.org/packages/83/e3/69d8711b3f2c5135e9cde5f063bc1605860f0b2c53086d40c04017eb1f77/sqlalchemy-2.0.48-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5aee45fd2c6c0f2b9cdddf48c48535e7471e42d6fb81adfde801da0bd5b93241", size = 3563519, upload-time = "2026-03-02T15:57:52.387Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/4f/a7cce98facca73c149ea4578981594aaa5fd841e956834931de503359336/sqlalchemy-2.0.48-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7cddca31edf8b0653090cbb54562ca027c421c58ddde2c0685f49ff56a1690e0", size = 3528611, upload-time = "2026-03-02T16:04:42.097Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/7d/5936c7a03a0b0cb0fa0cc425998821c6029756b0855a8f7ee70fba1de955/sqlalchemy-2.0.48-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7a936f1bb23d370b7c8cc079d5fce4c7d18da87a33c6744e51a93b0f9e97e9b3", size = 3472326, upload-time = "2026-03-02T15:57:54.423Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/33/cea7dfc31b52904efe3dcdc169eb4514078887dff1f5ae28a7f4c5d54b3c/sqlalchemy-2.0.48-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:e004aa9248e8cb0a5f9b96d003ca7c1c0a5da8decd1066e7b53f59eb8ce7c62b", size = 3478453, upload-time = "2026-03-02T16:04:44.584Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/95/32107c4d13be077a9cae61e9ae49966a35dc4bf442a8852dd871db31f62e/sqlalchemy-2.0.48-cp314-cp314t-win32.whl", hash = "sha256:b8438ec5594980d405251451c5b7ea9aa58dda38eb7ac35fb7e4c696712ee24f", size = 2147209, upload-time = "2026-03-02T15:52:54.274Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/d7/1e073da7a4bc645eb83c76067284a0374e643bc4be57f14cc6414656f92c/sqlalchemy-2.0.48-cp314-cp314t-win_amd64.whl", hash = "sha256:d854b3970067297f3a7fbd7a4683587134aa9b3877ee15aa29eea478dc68f933", size = 2182198, upload-time = "2026-03-02T15:52:55.606Z" },
+    { url = "https://files.pythonhosted.org/packages/46/2c/9664130905f03db57961b8980b05cab624afd114bf2be2576628a9f22da4/sqlalchemy-2.0.48-py3-none-any.whl", hash = "sha256:a66fe406437dd65cacd96a72689a3aaaecaebbcd62d81c5ac1c0fdbeac835096", size = 1940202, upload-time = "2026-03-02T15:52:43.285Z" },
+]
+
+[[package]]
 name = "sse-starlette"
 version = "3.3.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2561,6 +2793,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a", size = 49413, upload-time = "2026-02-07T10:45:33.841Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", size = 28926, upload-time = "2026-02-07T10:45:32.24Z" },
+]
+
+[[package]]
+name = "testcontainers"
+version = "4.14.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "docker" },
+    { name = "python-dotenv" },
+    { name = "typing-extensions" },
+    { name = "urllib3" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ca/ac/a597c3a0e02b26cbed6dd07df68be1e57684766fd1c381dee9b170a99690/testcontainers-4.14.2.tar.gz", hash = "sha256:1340ccf16fe3acd9389a6c9e1d9ab21d9fe99a8afdf8165f89c3e69c1967d239", size = 166841, upload-time = "2026-03-18T05:19:16.696Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/2d/26b8b30067d94339afee62c3edc9b803a6eb9332f521ba77d8aaab5de873/testcontainers-4.14.2-py3-none-any.whl", hash = "sha256:0d0522c3cd8f8d9627cda41f7a6b51b639fa57bdc492923c045117933c668d68", size = 125712, upload-time = "2026-03-18T05:19:15.29Z" },
 ]
 
 [[package]]
@@ -2809,6 +3057,92 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e3/ad/4a96c425be6fb67e0621e62d86c402b4a17ab2be7f7c055d9bd2f638b9e2/uvicorn-0.42.0.tar.gz", hash = "sha256:9b1f190ce15a2dd22e7758651d9b6d12df09a13d51ba5bf4fc33c383a48e1775", size = 85393, upload-time = "2026-03-16T06:19:50.077Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0a/89/f8827ccff89c1586027a105e5630ff6139a64da2515e24dafe860bd9ae4d/uvicorn-0.42.0-py3-none-any.whl", hash = "sha256:96c30f5c7abe6f74ae8900a70e92b85ad6613b745d4879eb9b16ccad15645359", size = 68830, upload-time = "2026-03-16T06:19:48.325Z" },
+]
+
+[[package]]
+name = "wrapt"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2e/64/925f213fdcbb9baeb1530449ac71a4d57fc361c053d06bf78d0c5c7cd80c/wrapt-2.1.2.tar.gz", hash = "sha256:3996a67eecc2c68fd47b4e3c564405a5777367adfd9b8abb58387b63ee83b21e", size = 81678, upload-time = "2026-03-06T02:53:25.134Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/d2/387594fb592d027366645f3d7cc9b4d7ca7be93845fbaba6d835a912ef3c/wrapt-2.1.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:4b7a86d99a14f76facb269dc148590c01aaf47584071809a70da30555228158c", size = 60669, upload-time = "2026-03-06T02:52:40.671Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/18/3f373935bc5509e7ac444c8026a56762e50c1183e7061797437ca96c12ce/wrapt-2.1.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:a819e39017f95bf7aede768f75915635aa8f671f2993c036991b8d3bfe8dbb6f", size = 61603, upload-time = "2026-03-06T02:54:21.032Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/7a/32758ca2853b07a887a4574b74e28843919103194bb47001a304e24af62f/wrapt-2.1.2-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:5681123e60aed0e64c7d44f72bbf8b4ce45f79d81467e2c4c728629f5baf06eb", size = 113632, upload-time = "2026-03-06T02:53:54.121Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/d5/eeaa38f670d462e97d978b3b0d9ce06d5b91e54bebac6fbed867809216e7/wrapt-2.1.2-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2b8b28e97a44d21836259739ae76284e180b18abbb4dcfdff07a415cf1016c3e", size = 115644, upload-time = "2026-03-06T02:54:53.33Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/09/2a41506cb17affb0bdf9d5e2129c8c19e192b388c4c01d05e1b14db23c00/wrapt-2.1.2-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:cef91c95a50596fcdc31397eb6955476f82ae8a3f5a8eabdc13611b60ee380ba", size = 112016, upload-time = "2026-03-06T02:54:43.274Z" },
+    { url = "https://files.pythonhosted.org/packages/64/15/0e6c3f5e87caadc43db279724ee36979246d5194fa32fed489c73643ba59/wrapt-2.1.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:dad63212b168de8569b1c512f4eac4b57f2c6934b30df32d6ee9534a79f1493f", size = 114823, upload-time = "2026-03-06T02:54:29.392Z" },
+    { url = "https://files.pythonhosted.org/packages/56/b2/0ad17c8248f4e57bedf44938c26ec3ee194715f812d2dbbd9d7ff4be6c06/wrapt-2.1.2-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:d307aa6888d5efab2c1cde09843d48c843990be13069003184b67d426d145394", size = 111244, upload-time = "2026-03-06T02:54:02.149Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/04/bcdba98c26f2c6522c7c09a726d5d9229120163493620205b2f76bd13c01/wrapt-2.1.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:c87cf3f0c85e27b3ac7d9ad95da166bf8739ca215a8b171e8404a2d739897a45", size = 113307, upload-time = "2026-03-06T02:54:12.428Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/1b/5e2883c6bc14143924e465a6fc5a92d09eeabe35310842a481fb0581f832/wrapt-2.1.2-cp310-cp310-win32.whl", hash = "sha256:d1c5fea4f9fe3762e2b905fdd67df51e4be7a73b7674957af2d2ade71a5c075d", size = 57986, upload-time = "2026-03-06T02:54:26.823Z" },
+    { url = "https://files.pythonhosted.org/packages/42/5a/4efc997bccadd3af5749c250b49412793bc41e13a83a486b2b54a33e240c/wrapt-2.1.2-cp310-cp310-win_amd64.whl", hash = "sha256:d8f7740e1af13dff2684e4d56fe604a7e04d6c94e737a60568d8d4238b9a0c71", size = 60336, upload-time = "2026-03-06T02:54:18Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/f5/a2bb833e20181b937e87c242645ed5d5aa9c373006b0467bfe1a35c727d0/wrapt-2.1.2-cp310-cp310-win_arm64.whl", hash = "sha256:1c6cc827c00dc839350155f316f1f8b4b0c370f52b6a19e782e2bda89600c7dc", size = 58757, upload-time = "2026-03-06T02:53:51.545Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/81/60c4471fce95afa5922ca09b88a25f03c93343f759aae0f31fb4412a85c7/wrapt-2.1.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:96159a0ee2b0277d44201c3b5be479a9979cf154e8c82fa5df49586a8e7679bb", size = 60666, upload-time = "2026-03-06T02:52:58.934Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/be/80e80e39e7cb90b006a0eaf11c73ac3a62bbfb3068469aec15cc0bc795de/wrapt-2.1.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:98ba61833a77b747901e9012072f038795de7fc77849f1faa965464f3f87ff2d", size = 61601, upload-time = "2026-03-06T02:53:00.487Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/be/d7c88cd9293c859fc74b232abdc65a229bb953997995d6912fc85af18323/wrapt-2.1.2-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:767c0dbbe76cae2a60dd2b235ac0c87c9cccf4898aef8062e57bead46b5f6894", size = 114057, upload-time = "2026-03-06T02:52:44.08Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/25/36c04602831a4d685d45a93b3abea61eca7fe35dab6c842d6f5d570ef94a/wrapt-2.1.2-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9c691a6bc752c0cc4711cc0c00896fcd0f116abc253609ef64ef930032821842", size = 116099, upload-time = "2026-03-06T02:54:56.74Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/4e/98a6eb417ef551dc277bec1253d5246b25003cf36fdf3913b65cb7657a56/wrapt-2.1.2-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f3b7d73012ea75aee5844de58c88f44cf62d0d62711e39da5a82824a7c4626a8", size = 112457, upload-time = "2026-03-06T02:53:52.842Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/a6/a6f7186a5297cad8ec53fd7578533b28f795fdf5372368c74bd7e6e9841c/wrapt-2.1.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:577dff354e7acd9d411eaf4bfe76b724c89c89c8fc9b7e127ee28c5f7bcb25b6", size = 115351, upload-time = "2026-03-06T02:53:32.684Z" },
+    { url = "https://files.pythonhosted.org/packages/97/6f/06e66189e721dbebd5cf20e138acc4d1150288ce118462f2fcbff92d38db/wrapt-2.1.2-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:3d7b6fd105f8b24e5bd23ccf41cb1d1099796524bcc6f7fbb8fe576c44befbc9", size = 111748, upload-time = "2026-03-06T02:53:08.455Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/43/4808b86f499a51370fbdbdfa6cb91e9b9169e762716456471b619fca7a70/wrapt-2.1.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:866abdbf4612e0b34764922ef8b1c5668867610a718d3053d59e24a5e5fcfc15", size = 113783, upload-time = "2026-03-06T02:53:02.02Z" },
+    { url = "https://files.pythonhosted.org/packages/91/2c/a3f28b8fa7ac2cefa01cfcaca3471f9b0460608d012b693998cd61ef43df/wrapt-2.1.2-cp311-cp311-win32.whl", hash = "sha256:5a0a0a3a882393095573344075189eb2d566e0fd205a2b6414e9997b1b800a8b", size = 57977, upload-time = "2026-03-06T02:53:27.844Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/c3/2b1c7bd07a27b1db885a2fab469b707bdd35bddf30a113b4917a7e2139d2/wrapt-2.1.2-cp311-cp311-win_amd64.whl", hash = "sha256:64a07a71d2730ba56f11d1a4b91f7817dc79bc134c11516b75d1921a7c6fcda1", size = 60336, upload-time = "2026-03-06T02:54:28.104Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/5c/76ece7b401b088daa6503d6264dd80f9a727df3e6042802de9a223084ea2/wrapt-2.1.2-cp311-cp311-win_arm64.whl", hash = "sha256:b89f095fe98bc12107f82a9f7d570dc83a0870291aeb6b1d7a7d35575f55d98a", size = 58756, upload-time = "2026-03-06T02:53:16.319Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/b6/1db817582c49c7fcbb7df6809d0f515af29d7c2fbf57eb44c36e98fb1492/wrapt-2.1.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:ff2aad9c4cda28a8f0653fc2d487596458c2a3f475e56ba02909e950a9efa6a9", size = 61255, upload-time = "2026-03-06T02:52:45.663Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/16/9b02a6b99c09227c93cd4b73acc3678114154ec38da53043c0ddc1fba0dc/wrapt-2.1.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6433ea84e1cfacf32021d2a4ee909554ade7fd392caa6f7c13f1f4bf7b8e8748", size = 61848, upload-time = "2026-03-06T02:53:48.728Z" },
+    { url = "https://files.pythonhosted.org/packages/af/aa/ead46a88f9ec3a432a4832dfedb84092fc35af2d0ba40cd04aea3889f247/wrapt-2.1.2-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:c20b757c268d30d6215916a5fa8461048d023865d888e437fab451139cad6c8e", size = 121433, upload-time = "2026-03-06T02:54:40.328Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/9f/742c7c7cdf58b59085a1ee4b6c37b013f66ac33673a7ef4aaed5e992bc33/wrapt-2.1.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:79847b83eb38e70d93dc392c7c5b587efe65b3e7afcc167aa8abd5d60e8761c8", size = 123013, upload-time = "2026-03-06T02:53:26.58Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/44/2c3dd45d53236b7ed7c646fcf212251dc19e48e599debd3926b52310fafb/wrapt-2.1.2-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f8fba1bae256186a83d1875b2b1f4e2d1242e8fac0f58ec0d7e41b26967b965c", size = 117326, upload-time = "2026-03-06T02:53:11.547Z" },
+    { url = "https://files.pythonhosted.org/packages/74/e2/b17d66abc26bd96f89dec0ecd0ef03da4a1286e6ff793839ec431b9fae57/wrapt-2.1.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e3d3b35eedcf5f7d022291ecd7533321c4775f7b9cd0050a31a68499ba45757c", size = 121444, upload-time = "2026-03-06T02:54:09.5Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/62/e2977843fdf9f03daf1586a0ff49060b1b2fc7ff85a7ea82b6217c1ae36e/wrapt-2.1.2-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:6f2c5390460de57fa9582bc8a1b7a6c86e1a41dfad74c5225fc07044c15cc8d1", size = 116237, upload-time = "2026-03-06T02:54:03.884Z" },
+    { url = "https://files.pythonhosted.org/packages/88/dd/27fc67914e68d740bce512f11734aec08696e6b17641fef8867c00c949fc/wrapt-2.1.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7dfa9f2cf65d027b951d05c662cc99ee3bd01f6e4691ed39848a7a5fffc902b2", size = 120563, upload-time = "2026-03-06T02:53:20.412Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/9f/b750b3692ed2ef4705cb305bd68858e73010492b80e43d2a4faa5573cbe7/wrapt-2.1.2-cp312-cp312-win32.whl", hash = "sha256:eba8155747eb2cae4a0b913d9ebd12a1db4d860fc4c829d7578c7b989bd3f2f0", size = 58198, upload-time = "2026-03-06T02:53:37.732Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/b2/feecfe29f28483d888d76a48f03c4c4d8afea944dbee2b0cd3380f9df032/wrapt-2.1.2-cp312-cp312-win_amd64.whl", hash = "sha256:1c51c738d7d9faa0b3601708e7e2eda9bf779e1b601dce6c77411f2a1b324a63", size = 60441, upload-time = "2026-03-06T02:52:47.138Z" },
+    { url = "https://files.pythonhosted.org/packages/44/e1/e328f605d6e208547ea9fd120804fcdec68536ac748987a68c47c606eea8/wrapt-2.1.2-cp312-cp312-win_arm64.whl", hash = "sha256:c8e46ae8e4032792eb2f677dbd0d557170a8e5524d22acc55199f43efedd39bf", size = 58836, upload-time = "2026-03-06T02:53:22.053Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/7a/d936840735c828b38d26a854e85d5338894cda544cb7a85a9d5b8b9c4df7/wrapt-2.1.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:787fd6f4d67befa6fe2abdffcbd3de2d82dfc6fb8a6d850407c53332709d030b", size = 61259, upload-time = "2026-03-06T02:53:41.922Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/88/9a9b9a90ac8ca11c2fdb6a286cb3a1fc7dd774c00ed70929a6434f6bc634/wrapt-2.1.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4bdf26e03e6d0da3f0e9422fd36bcebf7bc0eeb55fdf9c727a09abc6b9fe472e", size = 61851, upload-time = "2026-03-06T02:52:48.672Z" },
+    { url = "https://files.pythonhosted.org/packages/03/a9/5b7d6a16fd6533fed2756900fc8fc923f678179aea62ada6d65c92718c00/wrapt-2.1.2-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:bbac24d879aa22998e87f6b3f481a5216311e7d53c7db87f189a7a0266dafffb", size = 121446, upload-time = "2026-03-06T02:54:14.013Z" },
+    { url = "https://files.pythonhosted.org/packages/45/bb/34c443690c847835cfe9f892be78c533d4f32366ad2888972c094a897e39/wrapt-2.1.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:16997dfb9d67addc2e3f41b62a104341e80cac52f91110dece393923c0ebd5ca", size = 123056, upload-time = "2026-03-06T02:54:10.829Z" },
+    { url = "https://files.pythonhosted.org/packages/93/b9/ff205f391cb708f67f41ea148545f2b53ff543a7ac293b30d178af4d2271/wrapt-2.1.2-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:162e4e2ba7542da9027821cb6e7c5e068d64f9a10b5f15512ea28e954893a267", size = 117359, upload-time = "2026-03-06T02:53:03.623Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/3d/1ea04d7747825119c3c9a5e0874a40b33594ada92e5649347c457d982805/wrapt-2.1.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f29c827a8d9936ac320746747a016c4bc66ef639f5cd0d32df24f5eacbf9c69f", size = 121479, upload-time = "2026-03-06T02:53:45.844Z" },
+    { url = "https://files.pythonhosted.org/packages/78/cc/ee3a011920c7a023b25e8df26f306b2484a531ab84ca5c96260a73de76c0/wrapt-2.1.2-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:a9dd9813825f7ecb018c17fd147a01845eb330254dff86d3b5816f20f4d6aaf8", size = 116271, upload-time = "2026-03-06T02:54:46.356Z" },
+    { url = "https://files.pythonhosted.org/packages/98/fd/e5ff7ded41b76d802cf1191288473e850d24ba2e39a6ec540f21ae3b57cb/wrapt-2.1.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6f8dbdd3719e534860d6a78526aafc220e0241f981367018c2875178cf83a413", size = 120573, upload-time = "2026-03-06T02:52:50.163Z" },
+    { url = "https://files.pythonhosted.org/packages/47/c5/242cae3b5b080cd09bacef0591691ba1879739050cc7c801ff35c8886b66/wrapt-2.1.2-cp313-cp313-win32.whl", hash = "sha256:5c35b5d82b16a3bc6e0a04349b606a0582bc29f573786aebe98e0c159bc48db6", size = 58205, upload-time = "2026-03-06T02:53:47.494Z" },
+    { url = "https://files.pythonhosted.org/packages/12/69/c358c61e7a50f290958809b3c61ebe8b3838ea3e070d7aac9814f95a0528/wrapt-2.1.2-cp313-cp313-win_amd64.whl", hash = "sha256:f8bc1c264d8d1cf5b3560a87bbdd31131573eb25f9f9447bb6252b8d4c44a3a1", size = 60452, upload-time = "2026-03-06T02:53:30.038Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/66/c8a6fcfe321295fd8c0ab1bd685b5a01462a9b3aa2f597254462fc2bc975/wrapt-2.1.2-cp313-cp313-win_arm64.whl", hash = "sha256:3beb22f674550d5634642c645aba4c72a2c66fb185ae1aebe1e955fae5a13baf", size = 58842, upload-time = "2026-03-06T02:52:52.114Z" },
+    { url = "https://files.pythonhosted.org/packages/da/55/9c7052c349106e0b3f17ae8db4b23a691a963c334de7f9dbd60f8f74a831/wrapt-2.1.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:0fc04bc8664a8bc4c8e00b37b5355cffca2535209fba1abb09ae2b7c76ddf82b", size = 63075, upload-time = "2026-03-06T02:53:19.108Z" },
+    { url = "https://files.pythonhosted.org/packages/09/a8/ce7b4006f7218248dd71b7b2b732d0710845a0e49213b18faef64811ffef/wrapt-2.1.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:a9b9d50c9af998875a1482a038eb05755dfd6fe303a313f6a940bb53a83c3f18", size = 63719, upload-time = "2026-03-06T02:54:33.452Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/e5/2ca472e80b9e2b7a17f106bb8f9df1db11e62101652ce210f66935c6af67/wrapt-2.1.2-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2d3ff4f0024dd224290c0eabf0240f1bfc1f26363431505fb1b0283d3b08f11d", size = 152643, upload-time = "2026-03-06T02:52:42.721Z" },
+    { url = "https://files.pythonhosted.org/packages/36/42/30f0f2cefca9d9cbf6835f544d825064570203c3e70aa873d8ae12e23791/wrapt-2.1.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3278c471f4468ad544a691b31bb856374fbdefb7fee1a152153e64019379f015", size = 158805, upload-time = "2026-03-06T02:54:25.441Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/67/d08672f801f604889dcf58f1a0b424fe3808860ede9e03affc1876b295af/wrapt-2.1.2-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a8914c754d3134a3032601c6984db1c576e6abaf3fc68094bb8ab1379d75ff92", size = 145990, upload-time = "2026-03-06T02:53:57.456Z" },
+    { url = "https://files.pythonhosted.org/packages/68/a7/fd371b02e73babec1de6ade596e8cd9691051058cfdadbfd62a5898f3295/wrapt-2.1.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:ff95d4264e55839be37bafe1536db2ab2de19da6b65f9244f01f332b5286cfbf", size = 155670, upload-time = "2026-03-06T02:54:55.309Z" },
+    { url = "https://files.pythonhosted.org/packages/86/2d/9fe0095dfdb621009f40117dcebf41d7396c2c22dca6eac779f4c007b86c/wrapt-2.1.2-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:76405518ca4e1b76fbb1b9f686cff93aebae03920cc55ceeec48ff9f719c5f67", size = 144357, upload-time = "2026-03-06T02:54:24.092Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/b6/ec7b4a254abbe4cde9fa15c5d2cca4518f6b07d0f1b77d4ee9655e30280e/wrapt-2.1.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:c0be8b5a74c5824e9359b53e7e58bef71a729bacc82e16587db1c4ebc91f7c5a", size = 150269, upload-time = "2026-03-06T02:53:31.268Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/6b/2fabe8ebf148f4ee3c782aae86a795cc68ffe7d432ef550f234025ce0cfa/wrapt-2.1.2-cp313-cp313t-win32.whl", hash = "sha256:f01277d9a5fc1862f26f7626da9cf443bebc0abd2f303f41c5e995b15887dabd", size = 59894, upload-time = "2026-03-06T02:54:15.391Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/fb/9ba66fc2dedc936de5f8073c0217b5d4484e966d87723415cc8262c5d9c2/wrapt-2.1.2-cp313-cp313t-win_amd64.whl", hash = "sha256:84ce8f1c2104d2f6daa912b1b5b039f331febfeee74f8042ad4e04992bd95c8f", size = 63197, upload-time = "2026-03-06T02:54:41.943Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/1c/012d7423c95d0e337117723eb8ecf73c622ce15a97847e84cf3f8f26cd7e/wrapt-2.1.2-cp313-cp313t-win_arm64.whl", hash = "sha256:a93cd767e37faeddbe07d8fc4212d5cba660af59bdb0f6372c93faaa13e6e679", size = 60363, upload-time = "2026-03-06T02:54:48.093Z" },
+    { url = "https://files.pythonhosted.org/packages/39/25/e7ea0b417db02bb796182a5316398a75792cd9a22528783d868755e1f669/wrapt-2.1.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:1370e516598854e5b4366e09ce81e08bfe94d42b0fd569b88ec46cc56d9164a9", size = 61418, upload-time = "2026-03-06T02:53:55.706Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/0f/fa539e2f6a770249907757eaeb9a5ff4deb41c026f8466c1c6d799088a9b/wrapt-2.1.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:6de1a3851c27e0bd6a04ca993ea6f80fc53e6c742ee1601f486c08e9f9b900a9", size = 61914, upload-time = "2026-03-06T02:52:53.37Z" },
+    { url = "https://files.pythonhosted.org/packages/53/37/02af1867f5b1441aaeda9c82deed061b7cd1372572ddcd717f6df90b5e93/wrapt-2.1.2-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:de9f1a2bbc5ac7f6012ec24525bdd444765a2ff64b5985ac6e0692144838542e", size = 120417, upload-time = "2026-03-06T02:54:30.74Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/b7/0138a6238c8ba7476c77cf786a807f871672b37f37a422970342308276e7/wrapt-2.1.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:970d57ed83fa040d8b20c52fe74a6ae7e3775ae8cff5efd6a81e06b19078484c", size = 122797, upload-time = "2026-03-06T02:54:51.539Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/ad/819ae558036d6a15b7ed290d5b14e209ca795dd4da9c58e50c067d5927b0/wrapt-2.1.2-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3969c56e4563c375861c8df14fa55146e81ac11c8db49ea6fb7f2ba58bc1ff9a", size = 117350, upload-time = "2026-03-06T02:54:37.651Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/2d/afc18dc57a4600a6e594f77a9ae09db54f55ba455440a54886694a84c71b/wrapt-2.1.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:57d7c0c980abdc5f1d98b11a2aa3bb159790add80258c717fa49a99921456d90", size = 121223, upload-time = "2026-03-06T02:54:35.221Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/5b/5ec189b22205697bc56eb3b62aed87a1e0423e9c8285d0781c7a83170d15/wrapt-2.1.2-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:776867878e83130c7a04237010463372e877c1c994d449ca6aaafeab6aab2586", size = 116287, upload-time = "2026-03-06T02:54:19.654Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/2d/f84939a7c9b5e6cdd8a8d0f6a26cabf36a0f7e468b967720e8b0cd2bdf69/wrapt-2.1.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:fab036efe5464ec3291411fabb80a7a39e2dd80bae9bcbeeca5087fdfa891e19", size = 119593, upload-time = "2026-03-06T02:54:16.697Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/fe/ccd22a1263159c4ac811ab9374c061bcb4a702773f6e06e38de5f81a1bdc/wrapt-2.1.2-cp314-cp314-win32.whl", hash = "sha256:e6ed62c82ddf58d001096ae84ce7f833db97ae2263bff31c9b336ba8cfe3f508", size = 58631, upload-time = "2026-03-06T02:53:06.498Z" },
+    { url = "https://files.pythonhosted.org/packages/65/0a/6bd83be7bff2e7efaac7b4ac9748da9d75a34634bbbbc8ad077d527146df/wrapt-2.1.2-cp314-cp314-win_amd64.whl", hash = "sha256:467e7c76315390331c67073073d00662015bb730c566820c9ca9b54e4d67fd04", size = 60875, upload-time = "2026-03-06T02:53:50.252Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/c0/0b3056397fe02ff80e5a5d72d627c11eb885d1ca78e71b1a5c1e8c7d45de/wrapt-2.1.2-cp314-cp314-win_arm64.whl", hash = "sha256:da1f00a557c66225d53b095a97eace0fc5349e3bfda28fa34ffae238978ee575", size = 59164, upload-time = "2026-03-06T02:53:59.128Z" },
+    { url = "https://files.pythonhosted.org/packages/71/ed/5d89c798741993b2371396eb9d4634f009ff1ad8a6c78d366fe2883ea7a6/wrapt-2.1.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:62503ffbc2d3a69891cf29beeaccdb4d5e0a126e2b6a851688d4777e01428dbb", size = 63163, upload-time = "2026-03-06T02:52:54.873Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/8c/05d277d182bf36b0a13d6bd393ed1dec3468a25b59d01fba2dd70fe4d6ae/wrapt-2.1.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c7e6cd120ef837d5b6f860a6ea3745f8763805c418bb2f12eeb1fa6e25f22d22", size = 63723, upload-time = "2026-03-06T02:52:56.374Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/27/6c51ec1eff4413c57e72d6106bb8dec6f0c7cdba6503d78f0fa98767bcc9/wrapt-2.1.2-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:3769a77df8e756d65fbc050333f423c01ae012b4f6731aaf70cf2bef61b34596", size = 152652, upload-time = "2026-03-06T02:53:23.79Z" },
+    { url = "https://files.pythonhosted.org/packages/db/4c/d7dd662d6963fc7335bfe29d512b02b71cdfa23eeca7ab3ac74a67505deb/wrapt-2.1.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a76d61a2e851996150ba0f80582dd92a870643fa481f3b3846f229de88caf044", size = 158807, upload-time = "2026-03-06T02:53:35.742Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/4d/1e5eea1a78d539d346765727422976676615814029522c76b87a95f6bcdd/wrapt-2.1.2-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:6f97edc9842cf215312b75fe737ee7c8adda75a89979f8e11558dfff6343cc4b", size = 146061, upload-time = "2026-03-06T02:52:57.574Z" },
+    { url = "https://files.pythonhosted.org/packages/89/bc/62cabea7695cd12a288023251eeefdcb8465056ddaab6227cb78a2de005b/wrapt-2.1.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:4006c351de6d5007aa33a551f600404ba44228a89e833d2fadc5caa5de8edfbf", size = 155667, upload-time = "2026-03-06T02:53:39.422Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/99/6f2888cd68588f24df3a76572c69c2de28287acb9e1972bf0c83ce97dbc1/wrapt-2.1.2-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:a9372fc3639a878c8e7d87e1556fa209091b0a66e912c611e3f833e2c4202be2", size = 144392, upload-time = "2026-03-06T02:54:22.41Z" },
+    { url = "https://files.pythonhosted.org/packages/40/51/1dfc783a6c57971614c48e361a82ca3b6da9055879952587bc99fe1a7171/wrapt-2.1.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:3144b027ff30cbd2fca07c0a87e67011adb717eb5f5bd8496325c17e454257a3", size = 150296, upload-time = "2026-03-06T02:54:07.848Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/38/cbb8b933a0201076c1f64fc42883b0023002bdc14a4964219154e6ff3350/wrapt-2.1.2-cp314-cp314t-win32.whl", hash = "sha256:3b8d15e52e195813efe5db8cec156eebe339aaf84222f4f4f051a6c01f237ed7", size = 60539, upload-time = "2026-03-06T02:54:00.594Z" },
+    { url = "https://files.pythonhosted.org/packages/82/dd/e5176e4b241c9f528402cebb238a36785a628179d7d8b71091154b3e4c9e/wrapt-2.1.2-cp314-cp314t-win_amd64.whl", hash = "sha256:08ffa54146a7559f5b8df4b289b46d963a8e74ed16ba3687f99896101a3990c5", size = 63969, upload-time = "2026-03-06T02:54:39Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/99/79f17046cf67e4a95b9987ea129632ba8bcec0bc81f3fb3d19bdb0bd60cd/wrapt-2.1.2-cp314-cp314t-win_arm64.whl", hash = "sha256:72aaa9d0d8e4ed0e2e98019cea47a21f823c9dd4b43c7b77bba6679ffcca6a00", size = 60554, upload-time = "2026-03-06T02:53:14.132Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/c7/8528ac2dfa2c1e6708f647df7ae144ead13f0a31146f43c7264b4942bf12/wrapt-2.1.2-py3-none-any.whl", hash = "sha256:b8fd6fa2b2c4e7621808f8c62e8317f4aae56e59721ad933bac5239d913cf0e8", size = 43993, upload-time = "2026-03-06T02:53:12.905Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Adds `PostGISDataSource`, a DB-backed datasource that reads from any PostGIS table following the unified schema (`id TEXT, name TEXT, type TEXT, geom GEOMETRY(4326)`).

### Design decisions

**DB-agnostic.** Accepts a SQLAlchemy `Engine` or a URL string. No driver is bundled, the caller installs what they need (`psycopg2`, `psycopg`, …) and encodes it in the URL. SQLAlchemy is an optional extra (`[postgis]`), not a core dependency.

**Three-step search cascade** (stops at first non-empty result):

1. `unaccent(lower(name)) = :query`: normalized exact match
2. `word_similarity(unaccent(lower(name)), :query) > threshold`: token-aware pg_trgm fuzzy match.
3. `unaccent(name) ILIKE '%query%'`: broad last-resort substring fallback.

Each step opens its own connection to avoid poisoned-transaction state.

merge_segments after fetch, not before. Applying SQL LIMIT before merging would truncate the segment set and produce incomplete geometries for rivers/roads. The internal query uses min(max_results * 20, 100..2000), then merge_segments runs on the full result before slicing to max_results. This mirrors IGNBDCartoSource.search().
merge_segments / MERGE_TYPES moved to location_types.py as a shared source of truth, imported by both ign_bdcarto.py and postgis.py.

Type map handles both raw and normalized DB values. IGN_BDCARTO_TYPE_MAP now includes identity entries for fixed_type layers (e.g. "river" → ["river", "Estuaire", "Canal", …]), so layers like cours_d_eau whose normalized type is stored directly in the DB are matched correctly alongside layers whose raw source values are stored.
Docker Compose ships required extensions. demo/initdb/01_extensions.sql enables pg_trgm and unaccent automatically on first container start via the standard /docker-entrypoint-initdb.d hook.
