### PR TITLE
feat: add async aparse method to GeoFilterParser

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ Main class for parsing queries.
 **Methods:**
 
 - `parse(query: str) -> GeoQuery`: Parse a single query
+- `aparse(query: str) -> GeoQuery`: Async version of `parse` (awaits `ainvoke` on the LLM)
 - `parse_stream(query: str) -> AsyncGenerator[dict]`: Parse with streaming events
 - `parse_batch(queries: List[str]) -> List[GeoQuery]`: Parse multiple queries
 - `get_available_relations(category: Optional[str]) -> List[str]`: List available relations

--- a/demo/main.py
+++ b/demo/main.py
@@ -128,13 +128,13 @@ def _build_result_features(geo_query, reference_features: list) -> list:
     return result_features
 
 
-def _run_geo_query(query: str) -> "QueryResponse":
+async def _run_geo_query(query: str) -> "QueryResponse":
     """Parse a natural-language query and resolve it to a QueryResponse.
 
     Raises:
         ValueError: if the reference location is not found in the datasource.
     """
-    geo_query = parser.parse(query)
+    geo_query = await parser.aparse(query)
     location_name = geo_query.reference_location.name
     features = datasource.search(location_name, type=geo_query.reference_location.type)
     if not features:
@@ -157,7 +157,7 @@ class QueryResponse(BaseModel):
 @app.post("/api/query", response_model=QueryResponse)
 async def process_query(request: QueryRequest):
     try:
-        return _run_geo_query(request.query)
+        return await _run_geo_query(request.query)
     except ValueError as e:
         raise HTTPException(status_code=404, detail=str(e))
     except Exception as e:
@@ -260,7 +260,7 @@ async def parse_geo_query(user_query: str) -> dict[str, Any]:
             e.g. "Find all locations within walking distance from Zurich main railway station"
     """
     try:
-        return _run_geo_query(user_query).model_dump()
+        return (await _run_geo_query(user_query)).model_dump()
     except ValueError as e:
         raise ToolError(str(e))
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -76,6 +76,16 @@ parser = GeoFilterParser(llm=llm, confidence_threshold=0.8, strict_mode=True)
 
 See [`GeoQuery`](../api/etter.html#GeoQuery) for a full description of all output fields.
 
+## Async parsing
+
+Inside an event loop (e.g. a FastAPI handler), use the async counterpart `aparse` so the LLM call does not block other requests:
+
+```python
+geo_query = await parser.aparse("north of Lausanne")
+```
+
+`aparse` returns the same `GeoQuery` as `parse`; it differs only in that it awaits `ainvoke` on the underlying LLM. See [`aparse`](../api/etter.html#GeoFilterParser.aparse).
+
 ## Streaming
 
 For responsive UIs, use `parse_stream` to receive reasoning events in real time:

--- a/etter/parser.py
+++ b/etter/parser.py
@@ -106,6 +106,35 @@ class GeoFilterParser:
             available_types=available_types,
         )
 
+    def _unpack_response(self, response) -> GeoQuery:
+        """Extract and validate the GeoQuery from a structured-LLM response."""
+        parsed = response.get("parsed") if isinstance(response, dict) else response
+
+        if parsed is None:
+            raw = response.get("raw", "") if isinstance(response, dict) else ""
+            error = response.get("parsing_error") if isinstance(response, dict) else None
+            raise ParsingError(
+                message="Failed to parse query into structured format. "
+                "LLM may have returned invalid JSON or missed required fields.",
+                raw_response=str(raw),
+                original_error=error,
+            )
+
+        assert isinstance(parsed, GeoQuery), "Parsed result must be GeoQuery"
+        return parsed
+
+    def _finalize(self, geo_query: GeoQuery, query: str) -> GeoQuery:
+        """Set original_query and run the validation pipeline."""
+        if not geo_query.original_query or geo_query.original_query != query:
+            geo_query.original_query = query
+
+        return validate_query(
+            geo_query,
+            self.spatial_config,
+            confidence_threshold=self.confidence_threshold,
+            strict_mode=self.strict_mode,
+        )
+
     def parse(self, query: str) -> GeoQuery:
         """
         Parse a natural language location query into structured format.
@@ -160,10 +189,8 @@ class GeoFilterParser:
             >>> result.reference_location.name
             'Genève'
         """
-        # Format prompt with query
         formatted_messages = self.prompt.format_messages(query=query)
 
-        # Invoke LLM with structured output
         try:
             response = self.structured_llm.invoke(formatted_messages)
         except Exception as e:
@@ -173,35 +200,28 @@ class GeoFilterParser:
                 original_error=e,
             ) from e
 
-        # Check for parsing errors
-        parsed = response.get("parsed") if isinstance(response, dict) else response
+        return self._finalize(self._unpack_response(response), query)
 
-        if parsed is None:
-            raw = response.get("raw", "") if isinstance(response, dict) else ""
-            error = response.get("parsing_error") if isinstance(response, dict) else None
+    async def aparse(self, query: str) -> GeoQuery:
+        """
+        Asynchronously parse a natural language location query into structured format.
+
+        Async counterpart to :meth:`parse`. Uses ``ainvoke`` on the structured LLM
+        so it can be awaited inside event loops (e.g. FastAPI endpoints) without
+        blocking. Validation is synchronous and runs after the LLM call.
+        """
+        formatted_messages = self.prompt.format_messages(query=query)
+
+        try:
+            response = await self.structured_llm.ainvoke(formatted_messages)
+        except Exception as e:
             raise ParsingError(
-                message="Failed to parse query into structured format. "
-                "LLM may have returned invalid JSON or missed required fields.",
-                raw_response=str(raw),
-                original_error=error,
-            )
+                message=f"LLM invocation failed: {str(e)}",
+                raw_response="",
+                original_error=e,
+            ) from e
 
-        geo_query = parsed
-        assert isinstance(geo_query, GeoQuery), "Parsed result must be GeoQuery"
-
-        # Ensure original_query is set correctly
-        if not geo_query.original_query or geo_query.original_query != query:
-            geo_query.original_query = query
-
-        # Run validation pipeline
-        geo_query = validate_query(
-            geo_query,
-            self.spatial_config,
-            confidence_threshold=self.confidence_threshold,
-            strict_mode=self.strict_mode,
-        )
-
-        return geo_query
+        return self._finalize(self._unpack_response(response), query)
 
     async def parse_stream(self, query: str) -> AsyncGenerator[dict]:
         """
@@ -270,25 +290,11 @@ class GeoFilterParser:
                 ) from e
 
             yield {"type": "reasoning", "content": "Parsing LLM response into structured format"}
-            parsed = response.get("parsed") if isinstance(response, dict) else response
-
-            if parsed is None:
-                raw = response.get("raw", "") if isinstance(response, dict) else ""
-                error = response.get("parsing_error") if isinstance(response, dict) else None
+            try:
+                geo_query = self._unpack_response(response)
+            except ParsingError:
                 yield {"type": "error", "content": "Failed to parse response - invalid JSON or missing fields"}
-                raise ParsingError(
-                    message="Failed to parse query into structured format. "
-                    "LLM may have returned invalid JSON or missed required fields.",
-                    raw_response=str(raw),
-                    original_error=error,
-                )
-
-            geo_query = parsed
-            assert isinstance(geo_query, GeoQuery), "Parsed result must be GeoQuery"
-
-            # Ensure original_query is set correctly
-            if not geo_query.original_query or geo_query.original_query != query:
-                geo_query.original_query = query
+                raise
 
             if geo_query.confidence_breakdown.reasoning:
                 yield {
@@ -297,12 +303,7 @@ class GeoFilterParser:
                 }
 
             yield {"type": "reasoning", "content": "Validating spatial relation configuration"}
-            geo_query = validate_query(
-                geo_query,
-                self.spatial_config,
-                confidence_threshold=self.confidence_threshold,
-                strict_mode=self.strict_mode,
-            )
+            geo_query = self._finalize(geo_query, query)
 
             yield {"type": "reasoning", "content": "Query parsing completed successfully"}
             yield {"type": "data-response", "content": geo_query.model_dump()}

--- a/tests/test_parser_aparse.py
+++ b/tests/test_parser_aparse.py
@@ -1,0 +1,36 @@
+"""Tests for the async GeoFilterParser.aparse method."""
+
+import pytest
+
+from etter.exceptions import ParsingError
+from etter.parser import GeoFilterParser
+from tests.test_parser_streaming import MockLLM
+
+pytestmark = pytest.mark.anyio
+
+
+async def test_aparse_returns_geo_query():
+    parser = GeoFilterParser(llm=MockLLM(return_valid=True))
+
+    result = await parser.aparse("near Lake Geneva")
+
+    assert result.reference_location.name == "Lake Geneva"
+    assert result.spatial_relation.relation == "near"
+    assert result.spatial_relation.category == "buffer"
+    assert result.original_query == "near Lake Geneva"
+
+
+async def test_aparse_overwrites_original_query():
+    """aparse should set original_query to the caller's string even if the LLM returned a different one."""
+    parser = GeoFilterParser(llm=MockLLM(return_valid=True))
+
+    result = await parser.aparse("something else entirely")
+
+    assert result.original_query == "something else entirely"
+
+
+async def test_aparse_raises_parsing_error_on_invalid_response():
+    parser = GeoFilterParser(llm=MockLLM(return_valid=False))
+
+    with pytest.raises(ParsingError):
+        await parser.aparse("near Lake Geneva")


### PR DESCRIPTION
Mirrors the sync parse() path but awaits structured_llm.ainvoke, so callers running inside an event loop (FastAPI, etc.) can parse without blocking. Extracts shared _unpack_response / _finalize helpers to avoid duplication between parse and aparse.