### PR TITLE
feat: add additional_instructions parameter to GeoFilterParser

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,14 @@ Main class for parsing queries.
 - `get_available_relations(category: Optional[str]) -> List[str]`: List available relations
 - `describe_relation(name: str) -> str`: Get relation description
 
+**Constructor options (selected):**
+
+- `confidence_threshold`: Minimum confidence to accept (0–1, default `0.6`)
+- `strict_mode`: Raise `LowConfidenceError` instead of warning (default `False`)
+- `include_examples`: Include few-shot examples in the prompt (default `True`)
+- `datasource`: `GeoDataSource` instance — informs the LLM of available concrete types
+- `additional_instructions`: Free-form text injected as a system message after the main prompt and before few-shot examples. Use for region-specific endonyms, domain aliases, or organization-specific place names.
+
 ### GeoQuery
 
 Structured output model representing the parsed geographic filter.

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -116,3 +116,20 @@ parser = GeoFilterParser(llm=llm, spatial_config=config)
 ```
 
 See [Spatial Relations](/guide/spatial-relations) for the full list of built-ins and configuration options.
+
+## Additional Instructions
+
+Pass `additional_instructions` to inject caller-specific rules into the prompt without forking the default system prompt. The text is added as a system message after the main prompt and before the few-shot examples.
+
+Typical uses: region-specific endonyms, domain aliases, or organization-specific place names.
+
+```python
+parser = GeoFilterParser(
+    llm=llm,
+    additional_instructions=(
+        "This application serves Swiss users. "
+        "'Lac Léman' and 'Lake Geneva' both refer to the same body of water. "
+        "Prefer the French endonym when the query is in French."
+    ),
+)
+```

--- a/etter/parser.py
+++ b/etter/parser.py
@@ -48,6 +48,7 @@ class GeoFilterParser:
         strict_mode: bool = False,
         include_examples: bool = True,
         datasource: GeoDataSource | None = None,
+        additional_instructions: str | None = None,
     ):
         """
         Initialize the parser.
@@ -60,6 +61,10 @@ class GeoFilterParser:
             include_examples: Whether to include few-shot examples in prompt
             datasource: Optional GeoDataSource instance. If provided, the LLM will be informed
                        about the concrete types available in that datasource for better type inference.
+            additional_instructions: Free-form text injected as a system message after the main
+                       system prompt and before few-shot examples. Use this to add caller-specific
+                       rules such as region-specific endonyms, domain aliases, or
+                       organization-specific place names without forking the default prompt.
 
         Example:
             >>> from langchain.chat_models import init_chat_model
@@ -78,6 +83,7 @@ class GeoFilterParser:
         self.strict_mode = strict_mode
         self.include_examples = include_examples
         self.datasource = datasource
+        self.additional_instructions = additional_instructions
 
         # Build structured LLM
         self.structured_llm = self._build_structured_llm()
@@ -104,6 +110,7 @@ class GeoFilterParser:
             spatial_config=self.spatial_config,
             include_examples=self.include_examples,
             available_types=available_types,
+            additional_instructions=self.additional_instructions,
         )
 
     def parse(self, query: str) -> GeoQuery:

--- a/etter/prompts.py
+++ b/etter/prompts.py
@@ -172,6 +172,7 @@ def build_prompt_template(
     spatial_config: SpatialRelationConfig,
     include_examples: bool = True,
     available_types: list[str] | None = None,
+    additional_instructions: str | None = None,
 ) -> ChatPromptTemplate:
     """
     Build complete prompt template with system message, examples, and user message.
@@ -181,6 +182,9 @@ def build_prompt_template(
         include_examples: Whether to include few-shot examples (default: True)
         available_types: Concrete types available in the datasource (e.g., ["lake", "river", "city"]).
                         If provided, will be included in the prompt to help the LLM choose appropriate types.
+        additional_instructions: Free-form text injected as a system message after the main system prompt. Use this to inject
+                                 caller-specific rules (region-specific endonyms, domain aliases,
+                                 organization-specific place names) without forking the default prompt.
 
     Returns:
         ChatPromptTemplate ready for formatting
@@ -206,6 +210,10 @@ When inferring type, prefer these concrete types for better matching."""
     # Escape braces for ChatPromptTemplate
     system_prompt = system_prompt.replace("{", "{{").replace("}", "}}")
     messages.append(("system", system_prompt))
+
+    if additional_instructions:
+        escaped = additional_instructions.replace("{", "{{").replace("}", "}}")
+        messages.append(("system", escaped))
 
     # Few-shot examples (optional but recommended)
     if include_examples:

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -1,0 +1,31 @@
+"""
+Tests for prompt construction.
+"""
+
+from etter.parser import GeoFilterParser
+
+
+class MockLLM:
+    """Minimal mock LLM for prompt-construction tests (no API calls)."""
+
+    def with_structured_output(self, _schema, **kwargs):  # noqa: ARG002
+        return self
+
+
+def test_additional_instructions_in_prompt():
+    """additional_instructions appear as a system message before the examples."""
+    instructions = "Use French endonyms for Swiss locations."
+    mock_llm = MockLLM()
+    parser = GeoFilterParser(llm=mock_llm, additional_instructions=instructions)
+
+    messages = parser.prompt.format_messages(query="near Lake Geneva")
+    message_contents = [m.content for m in messages]
+
+    assert any(instructions in content for content in message_contents), (
+        "additional_instructions should be present in the prompt messages"
+    )
+
+    instructions_idx = next(i for i, c in enumerate(message_contents) if instructions in c)
+    examples_idx = next((i for i, c in enumerate(message_contents) if "EXAMPLES" in c), None)
+    if examples_idx is not None:
+        assert instructions_idx < examples_idx, "additional_instructions should appear before the few-shot examples"


### PR DESCRIPTION
Allows callers to inject custom rules (region-specific endonyms, domain aliases, organization-specific place names) as a dedicated system message positioned after the main system prompt and before the few-shot examples, without forking the default prompt.