### PR TITLE
perf: reduce prompt token count by ~34%

### DIFF
--- a/etter/examples.py
+++ b/etter/examples.py
@@ -131,29 +131,6 @@ EXAMPLES: list[ExampleQuery] = [
             original_query="hiking north of Bern",
         ),
     ),
-    # Spatial ambiguity - ring_only (English)
-    ExampleQuery(
-        input="on the lake shore",
-        language="en",
-        description="Spatial ambiguity - 'on' shores means excluding the water, using ring_only=true",
-        output=GeoQuery(
-            query_type="simple",
-            spatial_relation=SpatialRelation(relation="on_shores_of", category="buffer", explicit_distance=None),
-            reference_location=ReferenceLocation(
-                name="lake",
-                type="lake",
-                type_confidence=0.80,
-            ),
-            buffer_config=BufferConfig(distance_m=0, buffer_from="boundary", ring_only=True, inferred=False),
-            confidence_breakdown=ConfidenceScore(
-                overall=0.85,
-                location_confidence=0.80,
-                relation_confidence=0.90,
-                reasoning="'On the shore' indicates boundary/ring_only context",
-            ),
-            original_query="on the lake shore",
-        ),
-    ),
     # Time-based distance - walking (English)
     ExampleQuery(
         input="30 minutes walking from the station",
@@ -260,13 +237,10 @@ def format_examples_for_prompt() -> str:
     """
     examples_text = []
 
-    for i, ex in enumerate(EXAMPLES, 1):
-        examples_text.append(f"Example {i} ({ex.language}): {ex.description}")
-        examples_text.append(f"Input: {ex.input}")
-        examples_text.append("Output:")
-        # Use model_dump with JSON serialization for clean output, exclude None values
-        examples_text.append(ex.output.model_dump_json(indent=2, exclude_none=True))
-        examples_text.append("")  # Blank line between examples
+    for ex in EXAMPLES:
+        examples_text.append(f"Q: {ex.input}")
+        examples_text.append(f"A: {ex.output.model_dump_json(exclude_none=True, exclude={'original_query'})}")
+        examples_text.append("")
 
     return "\n".join(examples_text)
 

--- a/etter/prompts.py
+++ b/etter/prompts.py
@@ -16,12 +16,6 @@ Your ONLY task is to extract the GEOGRAPHIC FILTER from natural language queries
 - IGNORE: The subject/activity/feature being searched for (e.g., "hiking", "restaurants", "hotels")
 - The parent application handles subject/feature filtering - you focus solely on the geographic component
 
-Examples of scope:
-- "Hiking north of Lausanne" → Extract ONLY: "north of Lausanne" (ignore "Hiking")
-- "Restaurants in Bern" → Extract ONLY: "in Bern" (ignore "Restaurants")
-- "Hotels within 5km of Geneva" → Extract ONLY: "within 5km of Geneva" (ignore "Hotels")
-- "Hiking with children near Lake Geneva" → Extract ONLY: "near Lake Geneva" (ignore "Hiking with children")
-
 Your task is to analyze natural language queries (in any language) and extract:
 1. The reference location (what place is mentioned?)
 2. The spatial relationship (how are things related spatially?)
@@ -43,14 +37,11 @@ Spatial Relations:
    * "around X" → relation="near" (treat as proximity)
    * "from X" → relation="near" (proximity/distance from a location)
    * "away from X" → relation="near" (distance from a location)
-   * All proximity prepositions express distance to a location with optional explicit distance
 
 Location Type and Confidence:
 - type is OPTIONAL and should be used as a HINT, not a strict requirement
 - Set type when explicitly mentioned or strongly implied: "Lake Geneva" → type="lake", type_confidence=0.95
-- For ambiguous cases, set low confidence and omit type:
-  * "Bern" could be city OR canton → type_confidence=0.5
-  * "Neuchâtel" could be city, a lake or a canton → type_confidence=0.5
+- For ambiguous cases, set low confidence: "Bern" could be city OR canton → type_confidence=0.5
 - Use spatial relation as a hint for type:
   * "along X" suggests linear features (river, road, path) → moderate confidence
   * "in X" suggests areas (city, region, country) → moderate confidence
@@ -64,20 +55,18 @@ Type Hierarchy and Fuzzy Matching:
    * Concrete types: "lake", "river", "city", "mountain", "train_station", etc.
    * Categories: "water" (matches lake, river, pond, etc.), "settlement" (matches city, town, village, etc.)
 - When inferring type, prefer concrete types over categories for specificity
-- Examples of type categories:
+- Type categories:
    * water → [lake, river, pond, spring, waterfall, glacier, dam, etc.]
    * settlement → [city, town, village, hamlet, district]
    * administrative → [country, canton, municipality, region]
    * landforms → [mountain, peak, hill, pass, valley, ridge]
    * transport → [train_station, bus_stop, airport, road, bridge, etc.]
    * building → [building, religious_building, tower, monument]
-- The datasource may return any type from its category and apply fuzzy matching
 
 {available_types_info}
 
 Location Name Extraction:
 - Extract the location name as mentioned in the query (preserve the original form)
-- Examples: "Lausanne" → name="Lausanne", "Lake Geneva" → name="Lake Geneva", "Bern" → name="Bern"
 - For descriptive modifiers, extract the base location name:
   * "the center of Lausanne" → name="Lausanne"
   * "the outskirts of Geneva" → name="Geneva"
@@ -88,74 +77,31 @@ Location Name Extraction:
 Distance Extraction:
 - Extract explicit distances: "within 5km" → explicit_distance=5000
 - Convert units to meters: "5km" → 5000, "500 meters" → 500, "2 miles" → 3219
-- Recognize and calculate time-based distances using these speeds:
-  * Walking: 5 km/h
-  * Biking: 20 km/h
-- Examples:
-  * "10 minutes walk from X" → 10 * (5000/60) = 833m
-  * "15 minutes bike from X" → 15 * (20000/60) = 5000m
-  * "walking distance from X" → 1000m (typical walk)
-  * "biking distance from X" → 5000m (typical bike ride)
+- Time-based distances: walking=5km/h, biking=20km/h
+  * "10 minutes walk from X" → 833m; "15 minutes bike from X" → 5000m
+  * "walking distance from X" → 1000m; "biking distance from X" → 5000m
 
 Context-Aware Distance Inference:
-- When no explicit distance is stated, infer appropriate buffer distances based on query context
-- Set explicit_distance field with your inferred value (in meters) so the system uses your intelligent inference
-- Consider these contextual factors:
-
-  Activity/Transportation Context:
-  * Walking queries: 500m - 1km (e.g., "walking near the station" → 1000m)
-  * Biking queries: 3km - 5km (e.g., "biking near the lake" → 5000m)
-  * Driving queries: 10km - 20km (e.g., "driving near the city" → 15000m)
-  * General proximity (no activity): 5km default (e.g., "near Geneva" → 5000m)
-
-  Reference Feature Scale:
-  * Small features (station, monument, building): 500m - 1km
-  * Medium features (lake, town, park): 2km - 5km
-  * Large features (mountain, region, canton): 10km - 20km
-
-  Query Intent Signals:
-  * "close to", "next to", "right near": Tight proximity → 1000-2000m
-  * "around", "near": Standard proximity → 5000m
-  * "in the area of", "in the region of": Wide area → 10000m+
-
-  Erosion Context (in_the_heart_of relation):
-  * Small areas (neighborhood, small town): -500m erosion
-  * Medium areas (city, valley): -1000m erosion
-  * Large areas (canton, region): -2000m+ erosion
-
-- Examples of context-aware inference:
-  * "hiking near Lake Geneva" → explicit_distance=1000 (walking activity)
-  * "near Lausanne train station" → explicit_distance=1000 (small feature)
-  * "close to Geneva" → explicit_distance=2000 (intent: tight proximity)
-  * "in the area of Zurich" → explicit_distance=10000 (intent: wide area)
-  * "near the Alps" → explicit_distance=15000 (large feature scale)
-  * "in the heart of a small village" → explicit_distance=-500 (small area erosion)
-
-- If context is unclear or ambiguous, use sensible defaults: 5000m for proximity, -500m for erosion
+- When no explicit distance is stated, infer based on context and set explicit_distance:
+  * Walking queries: 500-1000m; biking: 3-5km; driving: 10-20km; default: 5km
+  * Small features (station, monument): 500m-1km; medium (lake, town): 2-5km; large (mountain, canton): 10-20km
+  * "close to/next to/right near": 1-2km; "around/near": 5km; "in the area of": 10km+
+  * Erosion (in_the_heart_of): small area=-500m; medium=-1000m; large=-2000m+
+- Examples: "hiking near Lake Geneva" → 1000m; "close to Geneva" → 2000m; "near the Alps" → 15000m
+- Default: 5000m for proximity, -500m for erosion
 
 Confidence Scoring:
 - overall: 0.9-1.0 = highly confident, 0.7-0.9 = confident, 0.5-0.7 = uncertain, <0.5 = very uncertain
 - Break down: location_confidence, relation_confidence
-- Always include reasoning to explain confidence scores and aid debugging
-- Lower confidence for:
-   * Ambiguous location names
-   * Unclear spatial relationships
-   * Generic references ("the train station" without city)
-   * Idiomatic expressions with multiple interpretations
+- Include reasoning to explain confidence scores and aid debugging
+- Lower confidence for ambiguous names, unclear relations, generic references ("the train station")
 
 Spatial Relation Selection Rules:
-- When the query refers to a specific side/bank of a linear feature (river, road):
-  * "rive droite", "right bank" → relation="right_bank"
-  * "rive gauche", "left bank" → relation="left_bank"
-  * Left/right is relative to the flow direction (downstream for rivers)
-- When reference location is a LINEAR feature (river, road, railway, path, stream, etc.):
-  * Prefer 'along' over 'near' for proximity/distance queries. Example: "à 2km de la Venoge" (river) → relation='along', not 'near'
-- When reference location is an AREA feature (lake, water body, region, canton, etc.):
-  * Prefer 'on_shores_of' over 'near' for proximity/distance queries. Example: "near Lake Geneva" → relation='on_shores_of', not 'near'
-- When reference location is a POINT feature that has a polygon (city, municipality, commune, village):
-  * Use 'near' with buffer_from='boundary' to search around the administrative boundary. Example: "near Lausanne" → relation='near', buffer_from='boundary', distance inferred (~2km)
-- When reference location is a POINT feature without a known polygon (building, monument, train station):
-  * Use 'near' with buffer_from='center'. Example: "near the train station" → relation='near', buffer_from='center'
+- River/road banks: "rive droite/right bank" → right_bank; "rive gauche/left bank" → left_bank
+- LINEAR features (river, road, railway): prefer 'along' over 'near'. "à 2km de la Venoge" → along
+- AREA features (lake, water body, region): prefer 'on_shores_of' over 'near'. "near Lake Geneva" → on_shores_of
+- POINT feature with polygon (city, municipality, village): use 'near' with buffer_from='boundary'. "near Lausanne" → near, boundary
+- POINT feature without polygon (building, monument, station): use 'near' with buffer_from='center'
 
 {spatial_relations}"""
 


### PR DESCRIPTION
Compact JSON in few-shot examples (no indent), remove original_query field from serialized examples (redundant with input), drop the description header per example, use compact Q:/A: format, remove one redundant example, and trim verbose sections from the system prompt.