### PR TITLE
feat: add geometry output format selection (GeoJSON, WKT, WKB)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -136,12 +136,12 @@ Resolves location names to geometries.
 
 Transforms reference geometries into search areas.
 
-- **Function**: `apply_spatial_relation(geometry, relation, buffer_config)`
+- **Function**: `apply_spatial_relation(geometry, relation, buffer_config, geometry_format="geojson")`
 - **Operations**:
   - **Containment**: Passthrough (exact boundary)
   - **Buffer**: Positive (expand), Negative (erode), Ring (donut)
   - **Directional**: Angular sector wedges (e.g., North = 90° wedge)
-- **Technology**: Uses `shapely` + `pyproj` internally, IO is standard WGS84 GeoJSON.
+- **Technology**: Uses `shapely` + `pyproj` internally, input is WGS84 GeoJSON; output format is configurable (`"geojson"` dict, `"wkt"` string, or `"wkb"` hex string).
 
 ---
 

--- a/docs/guide/spatial-relations.md
+++ b/docs/guide/spatial-relations.md
@@ -59,6 +59,37 @@ config.register_relation(RelationConfig(
 
 See [`SpatialRelationConfig`](../api/etter.html#SpatialRelationConfig) and [`RelationConfig`](../api/etter.html#RelationConfig) for all available options.
 
+## Output Geometry Format
+
+By default `apply_spatial_relation()` returns a GeoJSON geometry dict. Use the `geometry_format` parameter to request WKT or WKB instead:
+
+```python
+from etter import apply_spatial_relation
+from etter.models import SpatialRelation, BufferConfig
+
+geometry = datasource.search("Lausanne")[0]["geometry"]
+
+# GeoJSON dict (default)
+result = apply_spatial_relation(geometry, relation, buffer_config)
+
+# WKT string
+result_wkt = apply_spatial_relation(geometry, relation, buffer_config, geometry_format="wkt")
+
+# WKB hex string
+result_wkb = apply_spatial_relation(geometry, relation, buffer_config, geometry_format="wkb")
+```
+
+To convert raw datasource feature dicts, use `convert_feature_geometry()`:
+
+```python
+from etter import convert_feature_geometry
+
+feature = datasource.search("Lausanne")[0]
+feature_wkt = convert_feature_geometry(feature, "wkt")
+# feature_wkt["geometry"] is now a WKT string
+```
+
+
 ## Querying Available Relations
 
 ```python

--- a/etter/__init__.py
+++ b/etter/__init__.py
@@ -23,12 +23,14 @@ from .exceptions import (
     UnknownRelationError,
     ValidationError,
 )
+from .geometry_format import convert_feature_geometry, convert_geometry
 
 # Models (for type hints and result access)
 from .models import (
     BufferConfig,
     ConfidenceLevel,
     ConfidenceScore,
+    GeometryFormat,
     GeoQuery,
     ReferenceLocation,
     SpatialRelation,
@@ -51,6 +53,7 @@ __all__ = [
     "BufferConfig",
     "ConfidenceScore",
     "ConfidenceLevel",
+    "GeometryFormat",
     # Configuration
     "SpatialRelationConfig",
     "RelationConfig",
@@ -69,4 +72,6 @@ __all__ = [
     "PostGISDataSource",
     # Spatial
     "apply_spatial_relation",
+    "convert_geometry",
+    "convert_feature_geometry",
 ]

--- a/etter/geometry_format.py
+++ b/etter/geometry_format.py
@@ -1,0 +1,45 @@
+"""
+Utilities for converting GeoJSON geometry dicts to alternative output formats (WKT, WKB).
+"""
+
+from typing import Any
+
+from shapely.geometry import shape
+
+from .models import GeometryFormat
+
+
+def convert_geometry(geometry: dict[str, Any], fmt: GeometryFormat) -> dict[str, Any] | str:
+    """
+    Convert a GeoJSON geometry dict to the requested format.
+
+    Args:
+        geometry: GeoJSON geometry dict (e.g. {"type": "Point", "coordinates": [...]})
+        fmt: Target format — "geojson" returns the dict unchanged, "wkt" returns a WKT string,
+             "wkb" returns a hex-encoded WKB string.
+
+    Returns:
+        The geometry in the requested format.
+    """
+    if fmt == "geojson":
+        return geometry
+    geom = shape(geometry)
+    if fmt == "wkt":
+        return geom.wkt
+    return geom.wkb_hex
+
+
+def convert_feature_geometry(feature: dict[str, Any], fmt: GeometryFormat) -> dict[str, Any]:
+    """
+    Return a copy of a GeoJSON Feature dict with its geometry converted to the requested format.
+
+    Args:
+        feature: GeoJSON Feature dict with a "geometry" key.
+        fmt: Target geometry format.
+
+    Returns:
+        A new dict identical to the input except the "geometry" value is converted.
+    """
+    if fmt == "geojson":
+        return feature
+    return {**feature, "geometry": convert_geometry(feature["geometry"], fmt)}

--- a/etter/models.py
+++ b/etter/models.py
@@ -8,8 +8,8 @@ from pydantic import BaseModel, Field, model_validator
 
 ConfidenceLevel = Annotated[float, Field(ge=0.0, le=1.0, description="Confidence score between 0 and 1")]
 
-# Spatial relation categories
 RelationCategory = Literal["containment", "buffer", "directional"]
+GeometryFormat = Literal["geojson", "wkt", "wkb"]
 
 
 class ConfidenceScore(BaseModel):

--- a/etter/spatial.py
+++ b/etter/spatial.py
@@ -15,7 +15,8 @@ from shapely.geometry.linestring import LineString
 from shapely.geometry.polygon import Polygon
 from shapely.ops import linemerge, unary_union
 
-from .models import BufferConfig, SpatialRelation
+from .geometry_format import convert_geometry
+from .models import BufferConfig, GeometryFormat, SpatialRelation
 from .spatial_config import SpatialRelationConfig
 
 _DEFAULT_SPATIAL_CONFIG = SpatialRelationConfig()  # Module-level singleton for default spatial relation configuration.
@@ -26,7 +27,8 @@ def apply_spatial_relation(
     relation: SpatialRelation,
     buffer_config: BufferConfig | None = None,
     spatial_config: SpatialRelationConfig | None = None,
-) -> dict[str, Any]:
+    geometry_format: GeometryFormat = "geojson",
+) -> dict[str, Any] | str:
     """
     Transform a reference geometry according to a spatial relation.
 
@@ -43,9 +45,11 @@ def apply_spatial_relation(
         spatial_config: Spatial relation registry used to look up directional angles.
             Defaults to the module-level singleton; pass an explicit instance to
             avoid repeated construction when calling from a hot path.
+        geometry_format: Output format for the geometry. "geojson" (default) returns a
+            GeoJSON dict, "wkt" returns a WKT string, "wkb" returns a hex-encoded WKB string.
 
     Returns:
-        Transformed GeoJSON geometry dict in WGS84.
+        Transformed geometry in the requested format (GeoJSON dict, WKT string, or WKB hex string).
 
     Raises:
         ValueError: If buffer_config is missing for buffer/directional relations,
@@ -53,11 +57,19 @@ def apply_spatial_relation(
 
     Examples:
         >>> from etter.models import SpatialRelation, BufferConfig
-        >>> # Circular buffer
+        >>> # Circular buffer as GeoJSON (default)
         >>> result = apply_spatial_relation(
         ...     geometry={"type": "Point", "coordinates": [6.63, 46.52]},
         ...     relation=SpatialRelation(relation="near", category="buffer"),
         ...     buffer_config=BufferConfig(distance_m=5000, buffer_from="center"),
+        ... )
+
+        >>> # Same buffer as WKT
+        >>> result = apply_spatial_relation(
+        ...     geometry={"type": "Point", "coordinates": [6.63, 46.52]},
+        ...     relation=SpatialRelation(relation="near", category="buffer"),
+        ...     buffer_config=BufferConfig(distance_m=5000, buffer_from="center"),
+        ...     geometry_format="wkt",
         ... )
 
         >>> # Containment (passthrough)
@@ -67,11 +79,11 @@ def apply_spatial_relation(
         ... )
     """
     if relation.category == "containment":
-        return _apply_containment(geometry)
+        result = _apply_containment(geometry)
     elif relation.category == "buffer":
         if buffer_config is None:
             raise ValueError(f"Buffer relation '{relation.relation}' requires buffer_config")
-        return _apply_buffer(geometry, buffer_config)
+        result = _apply_buffer(geometry, buffer_config)
     elif relation.category == "directional":
         if buffer_config is None:
             raise ValueError(f"Directional relation '{relation.relation}' requires buffer_config")
@@ -79,9 +91,11 @@ def apply_spatial_relation(
         relation_config = cfg.get_config(relation.relation)
         direction = relation_config.direction_angle_degrees or 0
         sector_angle = relation_config.sector_angle_degrees or 90
-        return _apply_directional(geometry, buffer_config, direction, sector_angle)
+        result = _apply_directional(geometry, buffer_config, direction, sector_angle)
     else:
         raise ValueError(f"Unknown relation category: '{relation.category}'")
+
+    return convert_geometry(result, geometry_format)
 
 
 def _apply_containment(geometry: dict[str, Any]) -> dict[str, Any]:

--- a/tests/test_geometry_format.py
+++ b/tests/test_geometry_format.py
@@ -1,0 +1,134 @@
+"""
+Tests for geometry output format conversion.
+"""
+
+import re
+
+from shapely.geometry import mapping
+
+from etter.geometry_format import convert_feature_geometry, convert_geometry
+from etter.models import BufferConfig, SpatialRelation
+from etter.spatial import apply_spatial_relation
+
+POINT_GEOM = {"type": "Point", "coordinates": [6.63, 46.52]}
+POINT_FEATURE = {
+    "type": "Feature",
+    "id": "test-1",
+    "geometry": POINT_GEOM,
+    "bbox": [6.63, 46.52, 6.63, 46.52],
+    "properties": {"name": "Lausanne"},
+}
+
+
+class TestConvertGeometry:
+    def test_geojson_passthrough(self):
+        result = convert_geometry(POINT_GEOM, "geojson")
+        assert result is POINT_GEOM
+
+    def test_wkt_point(self):
+        result = convert_geometry(POINT_GEOM, "wkt")
+        assert isinstance(result, str)
+        assert result.startswith("POINT")
+        assert "6.63" in result
+        assert "46.52" in result
+
+    def test_wkb_point(self):
+        result = convert_geometry(POINT_GEOM, "wkb")
+        assert isinstance(result, str)
+        assert re.fullmatch(r"[0-9a-fA-F]+", result)
+
+    def test_wkb_is_hex_decodable(self):
+        result = convert_geometry(POINT_GEOM, "wkb")
+        decoded = bytes.fromhex(result)
+        assert len(decoded) > 0
+
+    def test_wkt_polygon(self):
+        from shapely.geometry import Polygon
+
+        poly = Polygon([(0, 0), (1, 0), (1, 1), (0, 1)])
+        geom = mapping(poly)
+        result = convert_geometry(geom, "wkt")
+        assert result.startswith("POLYGON")
+
+    def test_wkb_polygon(self):
+        from shapely.geometry import Polygon
+
+        poly = Polygon([(0, 0), (1, 0), (1, 1), (0, 1)])
+        geom = mapping(poly)
+        result = convert_geometry(geom, "wkb")
+        assert isinstance(result, str)
+        assert re.fullmatch(r"[0-9a-fA-F]+", result)
+
+
+class TestConvertFeatureGeometry:
+    def test_geojson_passthrough_returns_same_object(self):
+        result = convert_feature_geometry(POINT_FEATURE, "geojson")
+        assert result is POINT_FEATURE
+
+    def test_wkt_replaces_geometry(self):
+        result = convert_feature_geometry(POINT_FEATURE, "wkt")
+        assert isinstance(result["geometry"], str)
+        assert result["geometry"].startswith("POINT")
+
+    def test_wkb_replaces_geometry(self):
+        result = convert_feature_geometry(POINT_FEATURE, "wkb")
+        assert isinstance(result["geometry"], str)
+        assert re.fullmatch(r"[0-9a-fA-F]+", result["geometry"])
+
+    def test_other_fields_preserved(self):
+        result = convert_feature_geometry(POINT_FEATURE, "wkt")
+        assert result["type"] == "Feature"
+        assert result["id"] == "test-1"
+        assert result["bbox"] == [6.63, 46.52, 6.63, 46.52]
+        assert result["properties"]["name"] == "Lausanne"
+
+    def test_original_feature_not_mutated(self):
+        original_geometry = POINT_FEATURE["geometry"]
+        convert_feature_geometry(POINT_FEATURE, "wkt")
+        assert POINT_FEATURE["geometry"] is original_geometry
+
+
+class TestApplySpatialRelationFormat:
+    def test_default_format_is_geojson(self):
+        relation = SpatialRelation(relation="in", category="containment")
+        result = apply_spatial_relation(POINT_GEOM, relation)
+        assert isinstance(result, dict)
+        assert result["type"] == "Point"
+
+    def test_geojson_explicit(self):
+        relation = SpatialRelation(relation="in", category="containment")
+        result = apply_spatial_relation(POINT_GEOM, relation, geometry_format="geojson")
+        assert isinstance(result, dict)
+
+    def test_wkt_containment(self):
+        relation = SpatialRelation(relation="in", category="containment")
+        result = apply_spatial_relation(POINT_GEOM, relation, geometry_format="wkt")
+        assert isinstance(result, str)
+        assert result.startswith("POINT")
+
+    def test_wkb_containment(self):
+        relation = SpatialRelation(relation="in", category="containment")
+        result = apply_spatial_relation(POINT_GEOM, relation, geometry_format="wkb")
+        assert isinstance(result, str)
+        assert re.fullmatch(r"[0-9a-fA-F]+", result)
+
+    def test_wkt_buffer(self):
+        relation = SpatialRelation(relation="near", category="buffer")
+        config = BufferConfig(distance_m=5000, buffer_from="center")
+        result = apply_spatial_relation(POINT_GEOM, relation, config, geometry_format="wkt")
+        assert isinstance(result, str)
+        assert result.startswith("POLYGON")
+
+    def test_wkb_buffer(self):
+        relation = SpatialRelation(relation="near", category="buffer")
+        config = BufferConfig(distance_m=5000, buffer_from="center")
+        result = apply_spatial_relation(POINT_GEOM, relation, config, geometry_format="wkb")
+        assert isinstance(result, str)
+        assert re.fullmatch(r"[0-9a-fA-F]+", result)
+
+    def test_wkt_directional(self):
+        relation = SpatialRelation(relation="north_of", category="directional")
+        config = BufferConfig(distance_m=10000, buffer_from="center")
+        result = apply_spatial_relation(POINT_GEOM, relation, config, geometry_format="wkt")
+        assert isinstance(result, str)
+        assert result.startswith("POLYGON")


### PR DESCRIPTION
Add a geometry_format parameter to apply_spatial_relation() so callers can request WKT or WKB hex output instead of the default GeoJSON dict.