### PR TITLE
feat: add clipping and bordering spatial relations

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -100,7 +100,7 @@ Extracts intent from text using an LLM.
 - **Output**: `GeoQuery` object (Pydantic model)
 - **Key Features**:
   - Multilingual support
-  - 15 spatial relations (containment, buffer, directional)
+  - spatial relations: containment, buffer, directional, clipping
   - Distance inference ("10 min walk" → 833m)
   - Confidence scoring
 
@@ -141,6 +141,7 @@ Transforms reference geometries into search areas.
   - **Containment**: Passthrough (exact boundary)
   - **Buffer**: Positive (expand), Negative (erode), Ring (donut)
   - **Directional**: Angular sector wedges (e.g., North = 90° wedge)
+  - **Clipping**: Bbox half-plane intersection (e.g., northern half of a country)
 - **Technology**: Uses `shapely` + `pyproj` internally, input is WGS84 GeoJSON; output format is configurable (`"geojson"` dict, `"wkt"` string, or `"wkb"` hex string).
 
 ---
@@ -177,16 +178,17 @@ Standard GeoJSON dictionary structure:
 
 ---
 
-## Spatial Relations (15 Total)
+## Spatial Relations
 
 | Category (`category=`) | Relations | Behavior |
 |------------------------|-----------|----------|
 | **`containment`** | `in` | Exact geometry match |
 | **`buffer`** | `near`, `along` | Circular/Linear buffer with context-aware distances |
 | **`buffer`** (one-sided) | `left_bank`, `right_bank` | Buffer on one side of a linear feature relative to flow direction |
-| **`buffer`** (ring) | `on_shores_of` | Buffer - Original (Donut) |
+| **`buffer`** (ring) | `on_shores_of`, `bordering` | Buffer - Original (Donut) |
 | **`buffer`** (erosion) | `in_the_heart_of` | Negative buffer (shrink) with context-aware depth |
 | **`directional`** | `north_of`, `south_of`, `east_of`, `west_of`, `northeast_of`, `southeast_of`, `southwest_of`, `northwest_of` | 90° Sector Wedge |
+| **`clipping`** | `northern_part_of`, `southern_part_of`, `eastern_part_of`, `western_part_of` | Bbox half-plane intersection (sub-area of reference) |
 
 ---
 

--- a/demo/static/index.html
+++ b/demo/static/index.html
@@ -166,6 +166,10 @@
           <option value="15 min biking from Zurich main railway station" />
           <option value="along l'Orbe" />
           <option value="2km right bank of the Rhône" />
+          <option value="in the northern part of the Mittelland" />
+          <option value="in the southern part of the Walliser Alpen" />
+          <option value="in the western part of the Jura" />
+          <option value="in the eastern part of the Engiadina Bassa" />
         </datalist>
         <button onclick="executeQuery()" id="searchBtn">Search</button>
       </div>

--- a/docs/guide/spatial-relations.md
+++ b/docs/guide/spatial-relations.md
@@ -1,6 +1,6 @@
 # Spatial Relations
 
-etter supports 15 built-in spatial relations across three categories.
+etter supports 20 built-in spatial relations across four categories.
 
 ## Containment
 
@@ -20,10 +20,26 @@ etter supports 15 built-in spatial relations across three categories.
 | `right_bank` | Right bank of a linear feature (relative to flow direction) | 500 m |
 | `on_shores_of` | Ring buffer around a water boundary, excluding the water body | 1 km ring |
 | `in_the_heart_of` | Negative buffer (erosion) toward center | −500 m |
+| `bordering` | Thin ring just outside the reference boundary, for land-border adjacency | 2 km ring |
 
 **One-sided buffers:** `left_bank` and `right_bank` produce a buffer on a single side of a linear feature (river, road) relative to its direction of flow.
 
-**Ring buffer:** `on_shores_of` uses `ring_only=True` — the reference geometry itself is subtracted, leaving only the surrounding ring.
+**Ring buffer:** `on_shores_of` and `bordering` use `ring_only=True` — the reference geometry itself is subtracted, leaving only the surrounding ring.
+
+**Example:** `"cities bordering Germany"` → 2 km ring just outside Germany's boundary, excluding Germany itself.
+
+## Clipping
+
+Clipping relations clip the reference geometry to a directional half-plane. They answer *"what is in the northern/southern/eastern/western portion of X?"* — as opposed to directional relations, which answer *"what is north/south/east/west of X?"*.
+
+| Relation | Behavior |
+|----------|----------|
+| `northern_part_of` | Clip reference geometry to its northern bbox half (above midpoint latitude) |
+| `southern_part_of` | Clip reference geometry to its southern bbox half (below midpoint latitude) |
+| `eastern_part_of` | Clip reference geometry to its eastern bbox half (right of midpoint longitude) |
+| `western_part_of` | Clip reference geometry to its western bbox half (left of midpoint longitude) |
+
+**Example:** `"ski resorts in the northern part of Switzerland"` → Switzerland's polygon clipped to the area north of its bbox midpoint.
 
 ## Directional
 

--- a/etter/examples.py
+++ b/etter/examples.py
@@ -62,7 +62,6 @@ EXAMPLES: list[ExampleQuery] = [
                 relation_confidence=0.95,
                 reasoning=None,
             ),
-            original_query="restaurants in Geneva",
         ),
     ),
     # Buffer query with LLM-inferred distance (English)
@@ -85,7 +84,6 @@ EXAMPLES: list[ExampleQuery] = [
                 relation_confidence=0.95,
                 reasoning=None,
             ),
-            original_query="hotels within 5km of Lausanne",
         ),
     ),
     ExampleQuery(
@@ -100,14 +98,13 @@ EXAMPLES: list[ExampleQuery] = [
                 type="city",
                 type_confidence=0.95,
             ),
-            buffer_config=BufferConfig(distance_m=2000, buffer_from="boundary", ring_only=False, inferred=True),
+            buffer_config=BufferConfig(distance_m=5000, buffer_from="boundary", ring_only=False, inferred=True),
             confidence_breakdown=ConfidenceScore(
                 overall=0.90,
                 location_confidence=0.95,
                 relation_confidence=0.90,
-                reasoning="'near Lausanne' → city is a polygon feature → near with buffer from boundary",
+                reasoning="'near Lausanne' → city is a polygon feature → near with buffer from boundary, default 5km",
             ),
-            original_query="near Lausanne",
         ),
     ),
     # Directional (English)
@@ -130,7 +127,6 @@ EXAMPLES: list[ExampleQuery] = [
                 relation_confidence=0.95,
                 reasoning=None,
             ),
-            original_query="hiking north of Bern",
         ),
     ),
     # Time-based distance - walking (English)
@@ -153,7 +149,6 @@ EXAMPLES: list[ExampleQuery] = [
                 relation_confidence=0.90,
                 reasoning="'30 minutes walking' converted to 2500m buffer (5km/h walking speed)",
             ),
-            original_query="30 minutes walking from the station",
         ),
     ),
     # Complex query with multiple features (English)
@@ -176,7 +171,6 @@ EXAMPLES: list[ExampleQuery] = [
                 relation_confidence=0.90,
                 reasoning="'Heart of a small village' → small area erosion -500m",
             ),
-            original_query="in the heart of a small village",
         ),
     ),
     # Right bank of a river (French)
@@ -201,7 +195,6 @@ EXAMPLES: list[ExampleQuery] = [
                 relation_confidence=0.95,
                 reasoning="'rive droite' clearly indicates the right bank of the river",
             ),
-            original_query="rive droite du Rhône",
         ),
     ),
     # No named location — attribute-only query (English)
@@ -221,7 +214,47 @@ EXAMPLES: list[ExampleQuery] = [
                 relation_confidence=0.95,
                 reasoning="No named geographic location in query — only an attribute threshold (elevation < 600m)",
             ),
-            original_query="vineyards below 600 m",
+        ),
+    ),
+    # Clipping relation (English) — one example is sufficient; the LLM generalises to
+    # southern_part_of / eastern_part_of / western_part_of by analogy with the relation names.
+    ExampleQuery(
+        input="ski resorts in the northern part of the Mittelland",
+        language="en",
+        description="Clipping — clip reference geometry to its northern bbox half",
+        output=GeoQuery(
+            query_type="simple",
+            spatial_relation=SpatialRelation(relation="northern_part_of", category="clipping", explicit_distance=None),
+            reference_location=ReferenceLocation(name="Mittelland", type="region", type_confidence=0.92),
+            buffer_config=None,
+            confidence_breakdown=ConfidenceScore(
+                overall=0.92,
+                location_confidence=0.92,
+                relation_confidence=0.95,
+                reasoning="'in the northern part of the Mittelland' → clip to northern bbox half",
+            ),
+        ),
+    ),
+    # Bordering relation (English)
+    ExampleQuery(
+        input="cities bordering Germany",
+        language="en",
+        description="Bordering relation — ring buffer just outside Germany's boundary for land-border adjacency",
+        output=GeoQuery(
+            query_type="simple",
+            spatial_relation=SpatialRelation(relation="bordering", category="buffer", explicit_distance=None),
+            reference_location=ReferenceLocation(
+                name="Germany",
+                type="country",
+                type_confidence=0.98,
+            ),
+            buffer_config=BufferConfig(distance_m=2000, buffer_from="boundary", ring_only=True, inferred=True),
+            confidence_breakdown=ConfidenceScore(
+                overall=0.95,
+                location_confidence=0.98,
+                relation_confidence=0.95,
+                reasoning="'bordering Germany' → ring buffer just outside Germany's land border",
+            ),
         ),
     ),
     # Multilingual and complex (French)
@@ -244,7 +277,6 @@ EXAMPLES: list[ExampleQuery] = [
                 relation_confidence=0.90,
                 reasoning="'near Lake Geneva' → lake is an AREA feature → on_shores_of with ring buffer",
             ),
-            original_query="near Lake Geneva",
         ),
     ),
 ]

--- a/etter/models.py
+++ b/etter/models.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel, Field, model_validator
 
 ConfidenceLevel = Annotated[float, Field(ge=0.0, le=1.0, description="Confidence score between 0 and 1")]
 
-RelationCategory = Literal["containment", "buffer", "directional"]
+RelationCategory = Literal["containment", "buffer", "directional", "clipping"]
 GeometryFormat = Literal["geojson", "wkt", "wkb"]
 
 
@@ -102,8 +102,9 @@ class SpatialRelation(BaseModel):
     category: RelationCategory = Field(
         description="Category of spatial relation. "
         "'containment' = exact boundary matching (in), "
-        "'buffer' = proximity or erosion operations (near, around, on_shores_of, in_the_heart_of), "
-        "'directional' = sector-based queries (north_of, south_of, east_of, west_of)"
+        "'buffer' = proximity or erosion operations (near, around, on_shores_of, in_the_heart_of, bordering), "
+        "'directional' = sector-based queries (north_of, south_of, east_of, west_of), "
+        "'clipping' = clip reference to a directional half (northern_part_of, southern_part_of, etc.)"
     )
     explicit_distance: float | None = Field(
         None,
@@ -138,7 +139,10 @@ class GeoQuery(BaseModel):
         "Set to None for containment relations ('in').",
     )
     confidence_breakdown: ConfidenceScore = Field(description="Confidence scores for different aspects of the parse")
-    original_query: str = Field(description="Original query text exactly as provided by the user")
+    original_query: str = Field(
+        default="",
+        description="Original query text exactly as provided by the user",
+    )
 
     @model_validator(mode="after")
     def validate_buffer_config_consistency(self) -> "GeoQuery":
@@ -149,8 +153,8 @@ class GeoQuery(BaseModel):
                 f"{self.spatial_relation.category} relation '{self.spatial_relation.relation}' requires buffer_config"
             )
 
-        # Containment relations should not have buffer_config
-        if self.spatial_relation.category == "containment" and self.buffer_config is not None:
+        # Containment and clipping relations should not have buffer_config
+        if self.spatial_relation.category in ("containment", "clipping") and self.buffer_config is not None:
             raise ValueError(
                 f"{self.spatial_relation.category} relation '{self.spatial_relation.relation}' "
                 f"should not have buffer_config"

--- a/etter/parser.py
+++ b/etter/parser.py
@@ -132,8 +132,7 @@ class GeoFilterParser:
 
     def _finalize(self, geo_query: GeoQuery, query: str) -> GeoQuery:
         """Set original_query and run the validation pipeline."""
-        if not geo_query.original_query or geo_query.original_query != query:
-            geo_query.original_query = query
+        geo_query.original_query = query
 
         return validate_query(
             geo_query,

--- a/etter/spatial.py
+++ b/etter/spatial.py
@@ -9,7 +9,7 @@ Shapely is used internally for geometry operations.
 import math
 from typing import Any
 
-from shapely.geometry import MultiLineString, mapping, shape
+from shapely.geometry import MultiLineString, box, mapping, shape
 from shapely.geometry.base import BaseGeometry
 from shapely.geometry.linestring import LineString
 from shapely.geometry.polygon import Polygon
@@ -92,6 +92,11 @@ def apply_spatial_relation(
         direction = relation_config.direction_angle_degrees or 0
         sector_angle = relation_config.sector_angle_degrees or 90
         result = _apply_directional(geometry, buffer_config, direction, sector_angle)
+    elif relation.category == "clipping":
+        cfg = spatial_config if spatial_config is not None else _DEFAULT_SPATIAL_CONFIG
+        relation_config = cfg.get_config(relation.relation)
+        clip_direction = relation_config.clip_direction or "north"
+        result = _apply_clipping(geometry, clip_direction)
     else:
         raise ValueError(f"Unknown relation category: '{relation.category}'")
 
@@ -101,6 +106,35 @@ def apply_spatial_relation(
 def _apply_containment(geometry: dict[str, Any]) -> dict[str, Any]:
     """Return the geometry unchanged for containment relations."""
     return geometry
+
+
+def _apply_clipping(geometry: dict[str, Any], clip_direction: str) -> dict[str, Any]:
+    """
+    Clip a geometry to a directional half-plane using its bounding box midpoint.
+
+    For example, "northern_part_of Switzerland" clips Switzerland's polygon to its
+    northern half — the area above the bbox midpoint latitude.
+    """
+    geom = shape(geometry)
+    minx, miny, maxx, maxy = geom.bounds
+    midx = (minx + maxx) / 2
+    midy = (miny + maxy) / 2
+
+    if clip_direction == "north":
+        clip_box = box(minx, midy, maxx, maxy)
+    elif clip_direction == "south":
+        clip_box = box(minx, miny, maxx, midy)
+    elif clip_direction == "east":
+        clip_box = box(midx, miny, maxx, maxy)
+    else:  # west
+        clip_box = box(minx, miny, midx, maxy)
+
+    clipped = geom.intersection(clip_box)
+
+    if clipped.is_empty:
+        return geometry  # Fallback — should never happen for a valid half-plane clip
+
+    return mapping(clipped)
 
 
 def _apply_buffer(geometry: dict[str, Any], config: BufferConfig) -> dict[str, Any]:

--- a/etter/spatial_config.py
+++ b/etter/spatial_config.py
@@ -34,6 +34,7 @@ class RelationConfig:
     side: Literal["left", "right"] | None = None
     sector_angle_degrees: float | None = None
     direction_angle_degrees: float | None = None
+    clip_direction: Literal["north", "south", "east", "west"] | None = None
 
 
 class SpatialRelationConfig:
@@ -121,6 +122,57 @@ class SpatialRelationConfig:
                 description="Central area excluding periphery (negative buffer - erosion)",
                 default_distance_m=-500,
                 buffer_from="boundary",
+            )
+        )
+
+        self.register_relation(
+            RelationConfig(
+                name="bordering",
+                category="buffer",
+                description="Thin ring just outside the reference boundary, for land-border adjacency queries (e.g. 'cities bordering Germany')",
+                default_distance_m=2000,
+                buffer_from="boundary",
+                ring_only=True,
+            )
+        )
+
+        # ===== CLIPPING RELATIONS =====
+        # Clip the reference geometry to a directional half-plane using bbox intersection.
+        # These answer "what is in the northern/southern/eastern/western portion of X?"
+        # as opposed to directional relations which answer "what is north/south/etc. of X?".
+        self.register_relation(
+            RelationConfig(
+                name="northern_part_of",
+                category="clipping",
+                description="Northern half of the reference geometry (bbox clip to upper half)",
+                clip_direction="north",
+            )
+        )
+
+        self.register_relation(
+            RelationConfig(
+                name="southern_part_of",
+                category="clipping",
+                description="Southern half of the reference geometry (bbox clip to lower half)",
+                clip_direction="south",
+            )
+        )
+
+        self.register_relation(
+            RelationConfig(
+                name="eastern_part_of",
+                category="clipping",
+                description="Eastern half of the reference geometry (bbox clip to right half)",
+                clip_direction="east",
+            )
+        )
+
+        self.register_relation(
+            RelationConfig(
+                name="western_part_of",
+                category="clipping",
+                description="Western half of the reference geometry (bbox clip to left half)",
+                clip_direction="west",
             )
         )
 
@@ -282,7 +334,8 @@ class SpatialRelationConfig:
         # Add notes
         lines.append("\nNOTES:")
         lines.append("  • Negative distances indicate erosion/shrinking (e.g., in_the_heart_of)")
-        lines.append("  • Ring buffers exclude the reference feature itself (e.g., shores of lake)")
+        lines.append("  • Ring buffers exclude the reference feature itself (e.g., shores of lake, bordering)")
         lines.append("  • Buffer from 'center' vs 'boundary' determines buffer origin")
+        lines.append("  • Clipping relations return a sub-area of the reference geometry (not a buffer outward)")
 
         return "\n".join(lines)

--- a/tests/test_spatial.py
+++ b/tests/test_spatial.py
@@ -127,6 +127,29 @@ def test_right_side_buffer():
     assert not result_shape.contains(Point(1, 0.5))  # North of line (left)
 
 
+def test_clipping():
+    """Test all four clipping directions produce the correct half of the reference geometry."""
+    # 10x10 degree square centred at (5,5): lon 0-10, lat 0-10
+    poly = Polygon([(0, 0), (10, 0), (10, 10), (0, 10), (0, 0)])
+    geom = mapping(poly)
+
+    cases = [
+        ("northern_part_of", (0.0, 5.0, 10.0, 10.0)),
+        ("southern_part_of", (0.0, 0.0, 10.0, 5.0)),
+        ("eastern_part_of", (5.0, 0.0, 10.0, 10.0)),
+        ("western_part_of", (0.0, 0.0, 5.0, 10.0)),
+    ]
+    for relation_name, expected_bounds in cases:
+        relation = SpatialRelation(relation=relation_name, category="clipping")
+        result = apply_spatial_relation(geom, relation)
+        result_bounds = shape(result).bounds
+        assert result_bounds == expected_bounds, (
+            f"{relation_name}: expected bounds {expected_bounds}, got {result_bounds}"
+        )
+        # Clipped area should be exactly half the original
+        assert abs(shape(result).area - poly.area / 2) < 1e-9
+
+
 def test_side_none_symmetric_buffer():
     """Test that side=None preserves existing symmetric buffer behavior."""
     line = LineString([(0, 0), (2, 0)])


### PR DESCRIPTION
- Add 'clipping' category with northern/southern/eastern/western_part_of relations that clip a reference geometry to a directional bbox half-plane
- Add 'bordering' buffer relation (2km ring_only) for land-border adjacency queries
- Fix original_query field: default to '' so LLM output validates without it; _finalize always sets it post-parse
- Fix near Lausanne example distance (2000→5000m to match spatial_config default)
- Reduce clipping few-shot examples from 4 to 1; drop original_query from all examples
- Add test_clipping to test_spatial.py covering all four directions
- Update ARCHITECTURE.md and docs/guide/spatial-relations.md