### PR TITLE
feat: union multiple geometries in apply_spatial_relation

### DIFF
--- a/demo/main.py
+++ b/demo/main.py
@@ -113,25 +113,21 @@ parser = GeoFilterParser(llm, datasource=datasource)
 
 
 def _build_result_features(geo_query, reference_features: list) -> list:
-    """Apply spatial relations and return a flat list of (search_area, reference) Feature dicts."""
-    result_features = []
-    for i, reference_feature in enumerate(reference_features):
-        search_area = apply_spatial_relation(
-            reference_feature["geometry"], geo_query.spatial_relation, geo_query.buffer_config
-        )
-        result_features.append(
-            {
-                "type": "Feature",
-                "geometry": search_area,
-                "properties": {
-                    "role": "search_area",
-                    "relation": geo_query.spatial_relation.relation,
-                    "reference_index": i,
-                    "reference_name": reference_feature["properties"]["name"],
-                },
-            }
-        )
-        result_features.append(reference_feature)
+    """Build a flat list of (search_area, reference) Feature dicts for the given query."""
+    geometries = [f["geometry"] for f in reference_features]
+    search_area = apply_spatial_relation(geometries, geo_query.spatial_relation, geo_query.buffer_config)
+    result_features = [
+        {
+            "type": "Feature",
+            "geometry": search_area,
+            "properties": {
+                "role": "search_area",
+                "relation": geo_query.spatial_relation.relation,
+                "reference_name": reference_features[0]["properties"]["name"] if reference_features else None,
+            },
+        }
+    ]
+    result_features.extend(reference_features)
     return result_features
 
 

--- a/etter/spatial.py
+++ b/etter/spatial.py
@@ -23,61 +23,33 @@ _DEFAULT_SPATIAL_CONFIG = SpatialRelationConfig()  # Module-level singleton for 
 
 
 def apply_spatial_relation(
-    geometry: dict[str, Any],
+    geometry: dict[str, Any] | list[dict[str, Any]],
     relation: SpatialRelation,
     buffer_config: BufferConfig | None = None,
     spatial_config: SpatialRelationConfig | None = None,
     geometry_format: GeometryFormat = "geojson",
 ) -> dict[str, Any] | str:
-    """
-    Transform a reference geometry according to a spatial relation.
+    """Transform one or more reference geometries according to a spatial relation.
 
-    Converts the input GeoJSON geometry to a search area based on the
-    spatial relation category:
-    - Containment: returns the original geometry unchanged
-    - Buffer: applies positive (expand), negative (erode), or ring buffer
-    - Directional: creates an angular sector wedge
+    A list of geometries is unioned into one before the transformation, so that
+    features split across multiple datasource records (e.g. a river in segments)
+    produce a single coherent search area.
 
     Args:
-        geometry: GeoJSON geometry dict in WGS84 (EPSG:4326).
+        geometry: GeoJSON geometry dict or non-empty list of dicts (WGS84).
         relation: Spatial relation to apply.
-        buffer_config: Buffer configuration (required for buffer/directional relations).
-        spatial_config: Spatial relation registry used to look up directional angles.
-            Defaults to the module-level singleton; pass an explicit instance to
-            avoid repeated construction when calling from a hot path.
-        geometry_format: Output format for the geometry. "geojson" (default) returns a
-            GeoJSON dict, "wkt" returns a WKT string, "wkb" returns a hex-encoded WKB string.
+        buffer_config: Required for buffer/directional relations.
+        spatial_config: Relation registry; defaults to the module-level singleton.
+        geometry_format: "geojson" (default), "wkt", or "wkb".
 
     Returns:
-        Transformed geometry in the requested format (GeoJSON dict, WKT string, or WKB hex string).
-
-    Raises:
-        ValueError: If buffer_config is missing for buffer/directional relations,
-                     or if the relation category is unknown.
-
-    Examples:
-        >>> from etter.models import SpatialRelation, BufferConfig
-        >>> # Circular buffer as GeoJSON (default)
-        >>> result = apply_spatial_relation(
-        ...     geometry={"type": "Point", "coordinates": [6.63, 46.52]},
-        ...     relation=SpatialRelation(relation="near", category="buffer"),
-        ...     buffer_config=BufferConfig(distance_m=5000, buffer_from="center"),
-        ... )
-
-        >>> # Same buffer as WKT
-        >>> result = apply_spatial_relation(
-        ...     geometry={"type": "Point", "coordinates": [6.63, 46.52]},
-        ...     relation=SpatialRelation(relation="near", category="buffer"),
-        ...     buffer_config=BufferConfig(distance_m=5000, buffer_from="center"),
-        ...     geometry_format="wkt",
-        ... )
-
-        >>> # Containment (passthrough)
-        >>> result = apply_spatial_relation(
-        ...     geometry=city_polygon,
-        ...     relation=SpatialRelation(relation="in", category="containment"),
-        ... )
+        Transformed geometry in the requested format.
     """
+    if isinstance(geometry, list):
+        if not geometry:
+            raise ValueError("geometry list must not be empty")
+        geometry = mapping(unary_union([shape(g) for g in geometry]))
+
     if relation.category == "containment":
         result = _apply_containment(geometry)
     elif relation.category == "buffer":

--- a/tests/test_spatial.py
+++ b/tests/test_spatial.py
@@ -142,3 +142,54 @@ def test_side_none_symmetric_buffer():
     # Symmetric buffer covers both sides
     assert result_shape.contains(Point(1, 0.5))  # North of line
     assert result_shape.contains(Point(1, -0.5))  # South of line
+
+
+# --- list input (union) tests ---
+
+
+def test_list_input_buffer_union():
+    """Two line segments passed as a list produce the same buffer as the merged line."""
+    seg1 = {"type": "LineString", "coordinates": [[0.0, 0.0], [1.0, 0.0]]}
+    seg2 = {"type": "LineString", "coordinates": [[1.0, 0.0], [2.0, 0.0]]}
+    full = {"type": "LineString", "coordinates": [[0.0, 0.0], [1.0, 0.0], [2.0, 0.0]]}
+    relation = SpatialRelation(relation="along", category="buffer")
+    config = BufferConfig(distance_m=111320, buffer_from="boundary")
+
+    result = shape(apply_spatial_relation([seg1, seg2], relation, config))
+    reference = shape(apply_spatial_relation(full, relation, config))
+
+    assert not result.is_empty
+    assert abs(result.area - reference.area) / reference.area < 0.01
+
+
+def test_list_input_single_matches_dict():
+    """Single-element list gives the same result as passing the dict directly."""
+    geom = {"type": "Point", "coordinates": [0.0, 0.0]}
+    relation = SpatialRelation(relation="near", category="buffer")
+    config = BufferConfig(distance_m=111320, buffer_from="center")
+
+    assert shape(apply_spatial_relation(geom, relation, config)).equals_exact(
+        shape(apply_spatial_relation([geom], relation, config)), tolerance=1e-10
+    )
+
+
+def test_list_input_empty_raises():
+    """Empty list raises ValueError."""
+    import pytest
+
+    relation = SpatialRelation(relation="near", category="buffer")
+    config = BufferConfig(distance_m=5000, buffer_from="center")
+    with pytest.raises(ValueError, match="empty"):
+        apply_spatial_relation([], relation, config)
+
+
+def test_list_input_containment_union():
+    """Multiple polygons passed as a list are unioned for containment."""
+    poly1 = {"type": "Polygon", "coordinates": [[[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]]}
+    poly2 = {"type": "Polygon", "coordinates": [[[1, 0], [2, 0], [2, 1], [1, 1], [1, 0]]]}
+    relation = SpatialRelation(relation="in", category="containment")
+
+    result = shape(apply_spatial_relation([poly1, poly2], relation))
+
+    assert result.contains(shape(poly1))
+    assert result.contains(shape(poly2))


### PR DESCRIPTION
accept a list of GeoJSON geometry dicts in addition to a single dict; when a list is given the geometries are unioned before the spatial transformation, so features split across datasource records (e.g. a river in segments) produce a single coherent search area.