### PR TITLE
feat: area-based distance inference, geodesic spatial ops, type improvements

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -68,7 +68,7 @@ Here's what happens when you do a query in the demo:
 2. PARSER (Layer 1)
    - Extracts: spatial_relation="north_of", reference_location="Lausanne" (None if no named location)
    - Confidence: 0.95
-   - Buffer: 10000m (default for directional)
+   - Buffer: inferred=True, distance placeholder (final distance set in Layer 3 from geometry area)
    ↓
 3. DATASOURCE (Layer 2)
    - Searches: name="Lausanne", type="settlement" (inferred)
@@ -76,9 +76,10 @@ Here's what happens when you do a query in the demo:
    - Confidence: 1.0 (exact match)
    ↓
 4. SPATIAL OPERATIONS (Layer 3)
+   - Geodesic area of Lausanne geometry → bracket → radius (e.g. 5 000 m for a city polygon)
    - Centroid: (6.63, 46.52)
    - Direction: North (0°)
-   - Creates: 90° sector polygon extending 10km north
+   - Creates: 90° sector polygon extending ~5km north
    ↓
 5. OUTPUT: GeoJSON FeatureCollection
    {
@@ -101,7 +102,7 @@ Extracts intent from text using an LLM.
 - **Key Features**:
   - Multilingual support
   - spatial relations: containment, buffer, directional, clipping
-  - Distance inference ("10 min walk" → 833m)
+  - Distance inference ("10 min walk" → 833m set as `explicit_distance` by LLM; geometry-area-based default applied in Layer 3 when no explicit distance)
   - Confidence scoring
 
 ### 2. GeoDataSource (Layer 2)
@@ -142,6 +143,16 @@ Transforms reference geometries into search areas.
   - **Buffer**: Positive (expand), Negative (erode), Ring (donut)
   - **Directional**: Angular sector wedges (e.g., North = 90° wedge)
   - **Clipping**: Bbox half-plane intersection (e.g., northern half of a country)
+- **Area-based distance inference**: When `buffer_config.inferred=True` (no explicit distance in the query), `apply_spatial_relation` computes the geodesic area of the reference geometry (via `pyproj.Geod`) and selects a distance from area-based brackets:
+
+  | Geometry area | Proximity default | Erosion default |
+  |---|---|---|
+  | < 1 km² (point, station) | 500 m | −200 m |
+  | 1–50 km² (town, small lake) | 1 500 m | −500 m |
+  | 50–500 km² (city, medium region) | 5 000 m | −1 000 m |
+  | ≥ 500 km² (canton, country) | 15 000 m | −2 000 m |
+
+  If `explicit_distance` is set (user stated "within 5km", "30 min walk", etc.), it always takes precedence.
 - **Technology**: Uses `shapely` + `pyproj` internally, input is WGS84 GeoJSON; output format is configurable (`"geojson"` dict, `"wkt"` string, or `"wkb"` hex string).
 
 ---
@@ -183,10 +194,10 @@ Standard GeoJSON dictionary structure:
 | Category (`category=`) | Relations | Behavior |
 |------------------------|-----------|----------|
 | **`containment`** | `in` | Exact geometry match |
-| **`buffer`** | `near`, `along` | Circular/Linear buffer with context-aware distances |
+| **`buffer`** | `near`, `along` | Circular/Linear buffer; distance inferred from geometry area when not explicit |
 | **`buffer`** (one-sided) | `left_bank`, `right_bank` | Buffer on one side of a linear feature relative to flow direction |
-| **`buffer`** (ring) | `on_shores_of`, `bordering` | Buffer - Original (Donut) |
-| **`buffer`** (erosion) | `in_the_heart_of` | Negative buffer (shrink) with context-aware depth |
+| **`buffer`** (ring) | `on_shores_of`, `bordering` | Buffer - Original (Donut); distance inferred from geometry area when not explicit |
+| **`buffer`** (erosion) | `in_the_heart_of` | Negative buffer (shrink); erosion depth inferred from geometry area when not explicit |
 | **`directional`** | `north_of`, `south_of`, `east_of`, `west_of`, `northeast_of`, `southeast_of`, `southwest_of`, `northwest_of` | 90° Sector Wedge |
 | **`clipping`** | `northern_part_of`, `southern_part_of`, `eastern_part_of`, `western_part_of` | Bbox half-plane intersection (sub-area of reference) |
 

--- a/etter/datasources/ign_bdcarto.py
+++ b/etter/datasources/ign_bdcarto.py
@@ -219,7 +219,7 @@ def _index_keys(name: str) -> list[str]:
     return keys
 
 
-def _to_json_value(val: Any) -> Any:
+def _to_json_value(val: Any) -> str | float | int | bool | None:
     """
     Convert a pandas/numpy value to a JSON-serializable Python primitive.
 

--- a/etter/datasources/postgis.py
+++ b/etter/datasources/postgis.py
@@ -36,7 +36,10 @@ logger = logging.getLogger(__name__)
 if TYPE_CHECKING:
     # Only for type-checking; not imported at runtime to keep the base package
     # free of SQLAlchemy as a hard dependency.
+    import types
+
     from sqlalchemy import Engine
+    from sqlalchemy.engine import Connection, Row
 
 
 def _normalize_name(name: str) -> str:
@@ -46,7 +49,7 @@ def _normalize_name(name: str) -> str:
     return stripped.lower().strip()
 
 
-def _require_sqlalchemy() -> Any:
+def _require_sqlalchemy() -> types.ModuleType:
     """Import sqlalchemy, raising a clear error if it is not installed."""
     try:
         import sqlalchemy  # noqa: PLC0415
@@ -181,11 +184,11 @@ class PostGISDataSource:
         self._trgm_available: bool | None = None
         self._unaccent_available: bool | None = None
 
-    def _get_connection(self) -> Any:
+    def _get_connection(self) -> Connection:
         """Return a SQLAlchemy connection from the engine."""
         return self._engine.connect()
 
-    def _check_trgm(self, conn: Any) -> bool:
+    def _check_trgm(self, conn: Connection) -> bool:
         """Return True if pg_trgm extension is available in the database."""
         if self._trgm_available is not None:
             return self._trgm_available
@@ -198,7 +201,7 @@ class PostGISDataSource:
             self._trgm_available = False
         return self._trgm_available
 
-    def _check_unaccent(self, conn: Any) -> bool:
+    def _check_unaccent(self, conn: Connection) -> bool:
         """Return True if the unaccent extension is available in the database."""
         if self._unaccent_available is not None:
             return self._unaccent_available
@@ -220,7 +223,7 @@ class PostGISDataSource:
             return None
         return self._raw_to_normalized.get(raw_type, raw_type)
 
-    def _row_to_feature(self, row: Any) -> dict[str, Any]:
+    def _row_to_feature(self, row: Row) -> dict[str, Any]:
         """Convert a SQLAlchemy Row to a GeoJSON Feature dict."""
         feature_id = str(row.id)
         name = str(row.name)
@@ -333,8 +336,8 @@ class PostGISDataSource:
 
     def _search_normalized(
         self,
-        conn: Any,
-        sa: Any,
+        conn: Connection,
+        sa: types.ModuleType,
         cols: str,
         name: str,
         type_filter: list[str] | None,
@@ -369,8 +372,8 @@ class PostGISDataSource:
 
     def _search_ilike(
         self,
-        conn: Any,
-        sa: Any,
+        conn: Connection,
+        sa: types.ModuleType,
         cols: str,
         name: str,
         type_filter: list[str] | None,
@@ -406,8 +409,8 @@ class PostGISDataSource:
 
     def _search_fuzzy(
         self,
-        conn: Any,
-        sa: Any,
+        conn: Connection,
+        sa: types.ModuleType,
         cols: str,
         name: str,
         type_filter: list[str] | None,

--- a/etter/prompts.py
+++ b/etter/prompts.py
@@ -14,7 +14,6 @@ CRITICAL SCOPE LIMITATION:
 Your ONLY task is to extract the GEOGRAPHIC FILTER from natural language queries.
 - Extract: reference location + spatial relation + distance parameters
 - IGNORE: The subject/activity/feature being searched for (e.g., "hiking", "restaurants", "hotels")
-- The parent application handles subject/feature filtering - you focus solely on the geographic component
 
 Your task is to analyze natural language queries (in any language) and extract:
 1. The reference location (what place is mentioned?)
@@ -91,13 +90,10 @@ Distance Extraction:
   * "walking distance from X" → 1000m; "biking distance from X" → 5000m
 
 Context-Aware Distance Inference:
-- When no explicit distance is stated, infer based on context and set explicit_distance:
-  * Walking queries: 500-1000m; biking: 3-5km; driving: 10-20km; default: 5km
-  * Small features (station, monument): 500m-1km; medium (lake, town): 2-5km; large (mountain, canton): 10-20km
-  * "close to/next to/right near": 1-2km; "around/near": 5km; "in the area of": 10km+
-  * Erosion (in_the_heart_of): small area=-500m; medium=-1000m; large=-2000m+
-- Examples: "hiking near Lake Geneva" → 1000m; "close to Geneva" → 2000m; "near the Alps" → 15000m
-- Default: 5000m for proximity, -500m for erosion
+- Set explicit_distance only when the query text gives a clear signal:
+  * Travel mode/time: "30 min walk" → 2500m, "biking distance" → 5000m, "10 min drive" → 5000m+
+  * Strong phrasing: "close to/next to" → 1-2km; "in the area of" → 10km+
+- Leave explicit_distance null when no textual signal is present — the system will infer a default from the geometry.
 
 Confidence Scoring:
 - overall: 0.9-1.0 = highly confident, 0.7-0.9 = confident, 0.5-0.7 = uncertain, <0.5 = very uncertain
@@ -118,9 +114,7 @@ Spatial Relation Selection Rules:
 
 USER_TEMPLATE = """Parse the following location query:
 
-Query: {query}
-
-Return a structured JSON response following the GeoQuery schema."""
+Query: {query}"""
 
 
 def build_prompt_template(

--- a/etter/spatial.py
+++ b/etter/spatial.py
@@ -6,20 +6,107 @@ All inputs and outputs are GeoJSON dicts in WGS84 (EPSG:4326).
 Shapely is used internally for geometry operations.
 """
 
-import math
 from typing import Any
 
+from pyproj import Geod, Transformer
 from shapely.geometry import MultiLineString, box, mapping, shape
 from shapely.geometry.base import BaseGeometry
 from shapely.geometry.linestring import LineString
 from shapely.geometry.polygon import Polygon
-from shapely.ops import linemerge, unary_union
+from shapely.ops import linemerge, transform, unary_union
 
 from .geometry_format import convert_geometry
 from .models import BufferConfig, GeometryFormat, SpatialRelation
 from .spatial_config import SpatialRelationConfig
 
 _DEFAULT_SPATIAL_CONFIG = SpatialRelationConfig()  # Module-level singleton for default spatial relation configuration.
+_GEOD = Geod(ellps="WGS84")  # Geodesic calculator for accurate area and arc computation.
+
+
+def _local_transformers(lon: float, lat: float) -> tuple[Transformer, Transformer]:
+    """Return (to_local, to_wgs84) Transformers for an azimuthal equidistant CRS
+    centred at (lon, lat).  Distances in the local CRS are in metres with low
+    distortion within a few hundred kilometres of the centre point.
+    """
+    aeqd = f"+proj=aeqd +lat_0={lat} +lon_0={lon} +datum=WGS84 +units=m"
+    to_local = Transformer.from_crs("EPSG:4326", aeqd, always_xy=True)
+    to_wgs84 = Transformer.from_crs(aeqd, "EPSG:4326", always_xy=True)
+    return to_local, to_wgs84
+
+
+# Area thresholds in m² used for distance inference from geometry size.
+# Brackets: point/tiny (<1 km²), small (1–50 km²), medium (50–500 km²), large (>500 km²)
+_AREA_DISTANCE_BRACKETS: list[tuple[float, int]] = [
+    (1_000_000, 500),  # < 1 km²   → 500 m
+    (50_000_000, 1_500),  # < 50 km²  → 1 500 m
+    (500_000_000, 5_000),  # < 500 km² → 5 000 m
+]
+_AREA_DISTANCE_DEFAULT = 15_000  # ≥ 500 km² → 15 000 m
+
+# Erosion distances mirror the positive brackets (negative values).
+_AREA_EROSION_BRACKETS: list[tuple[float, int]] = [
+    (1_000_000, -200),
+    (50_000_000, -500),
+    (500_000_000, -1_000),
+]
+_AREA_EROSION_DEFAULT = -2_000
+
+
+def _area_m2(geom: BaseGeometry) -> float:
+    """Return the geodesic area of a Shapely geometry in m² (WGS84 ellipsoid).
+
+    Uses pyproj.Geod.geometry_area_perimeter for accurate area computation
+    without the need for reprojection.  The result is always non-negative.
+    """
+    if geom.area == 0:
+        # Non-polygonal geometries (points, lines) have zero planar area; short-
+        # circuit to avoid the artefact where pyproj implicitly closes a
+        # LineString into a ring and returns a spurious non-zero value.
+        return 0.0
+    area, _ = _GEOD.geometry_area_perimeter(geom)
+    return abs(area)
+
+
+def _infer_distance_from_area(area_m2: float, erosion: bool) -> int:
+    """Return a default buffer distance (m) based on geometry area.
+
+    Args:
+        area_m2: Geometry area in square metres.
+        erosion: True for erosion (negative buffer) relations.
+
+    Returns:
+        Distance in metres (negative for erosion).
+    """
+    brackets = _AREA_EROSION_BRACKETS if erosion else _AREA_DISTANCE_BRACKETS
+    default = _AREA_EROSION_DEFAULT if erosion else _AREA_DISTANCE_DEFAULT
+    for threshold, distance in brackets:
+        if area_m2 < threshold:
+            return distance
+    return default
+
+
+def _refine_buffer_config(
+    geom: BaseGeometry,
+    buffer_config: BufferConfig,
+    relation: SpatialRelation,
+) -> BufferConfig:
+    """Replace inferred distance with an area-based estimate.
+
+    Only acts when ``buffer_config.inferred`` is True and no explicit distance
+    was stated by the user (``relation.explicit_distance is None``).  The
+    geometry area drives bracket selection so that tiny features get small
+    buffers and large regions get large ones.
+
+    Returns the (possibly updated) BufferConfig — mutates in place for
+    consistency with the rest of the pipeline.
+    """
+    if not buffer_config.inferred or relation.explicit_distance is not None:
+        return buffer_config
+
+    erosion = buffer_config.distance_m < 0
+    area = _area_m2(geom)
+    buffer_config.distance_m = _infer_distance_from_area(area, erosion)
+    return buffer_config
 
 
 def apply_spatial_relation(
@@ -35,6 +122,11 @@ def apply_spatial_relation(
     features split across multiple datasource records (e.g. a river in segments)
     produce a single coherent search area.
 
+    When ``buffer_config.inferred`` is True (i.e. no explicit distance was
+    stated), the buffer distance is refined from the actual geometry area so
+    that small features receive small buffers and large regions receive large
+    ones.
+
     Args:
         geometry: GeoJSON geometry dict or non-empty list of dicts (WGS84).
         relation: Spatial relation to apply.
@@ -48,14 +140,22 @@ def apply_spatial_relation(
     if isinstance(geometry, list):
         if not geometry:
             raise ValueError("geometry list must not be empty")
-        geometry = mapping(unary_union([shape(g) for g in geometry]))
+        geom = unary_union([shape(g) for g in geometry])
+        geom_dict: dict[str, Any] = mapping(geom)
+    else:
+        geom = shape(geometry)
+        geom_dict = geometry
+
+    # Refine inferred buffer distance from geometry area before dispatching.
+    if buffer_config is not None and buffer_config.inferred:
+        buffer_config = _refine_buffer_config(geom, buffer_config, relation)
 
     if relation.category == "containment":
-        result = _apply_containment(geometry)
+        result = geom_dict
     elif relation.category == "buffer":
         if buffer_config is None:
             raise ValueError(f"Buffer relation '{relation.relation}' requires buffer_config")
-        result = _apply_buffer(geometry, buffer_config)
+        result = _apply_buffer(geom, buffer_config)
     elif relation.category == "directional":
         if buffer_config is None:
             raise ValueError(f"Directional relation '{relation.relation}' requires buffer_config")
@@ -63,31 +163,25 @@ def apply_spatial_relation(
         relation_config = cfg.get_config(relation.relation)
         direction = relation_config.direction_angle_degrees or 0
         sector_angle = relation_config.sector_angle_degrees or 90
-        result = _apply_directional(geometry, buffer_config, direction, sector_angle)
+        result = _apply_directional(geom, buffer_config, direction, sector_angle)
     elif relation.category == "clipping":
         cfg = spatial_config if spatial_config is not None else _DEFAULT_SPATIAL_CONFIG
         relation_config = cfg.get_config(relation.relation)
         clip_direction = relation_config.clip_direction or "north"
-        result = _apply_clipping(geometry, clip_direction)
+        result = _apply_clipping(geom, clip_direction)
     else:
         raise ValueError(f"Unknown relation category: '{relation.category}'")
 
     return convert_geometry(result, geometry_format)
 
 
-def _apply_containment(geometry: dict[str, Any]) -> dict[str, Any]:
-    """Return the geometry unchanged for containment relations."""
-    return geometry
-
-
-def _apply_clipping(geometry: dict[str, Any], clip_direction: str) -> dict[str, Any]:
+def _apply_clipping(geom: BaseGeometry, clip_direction: str) -> dict[str, Any]:
     """
     Clip a geometry to a directional half-plane using its bounding box midpoint.
 
     For example, "northern_part_of Switzerland" clips Switzerland's polygon to its
     northern half — the area above the bbox midpoint latitude.
     """
-    geom = shape(geometry)
     minx, miny, maxx, maxy = geom.bounds
     midx = (minx + maxx) / 2
     midy = (miny + maxy) / 2
@@ -104,12 +198,12 @@ def _apply_clipping(geometry: dict[str, Any], clip_direction: str) -> dict[str, 
     clipped = geom.intersection(clip_box)
 
     if clipped.is_empty:
-        return geometry  # Fallback — should never happen for a valid half-plane clip
+        return mapping(geom)  # Fallback — should never happen for a valid half-plane clip
 
     return mapping(clipped)
 
 
-def _apply_buffer(geometry: dict[str, Any], config: BufferConfig) -> dict[str, Any]:
+def _apply_buffer(geom: BaseGeometry, config: BufferConfig) -> dict[str, Any]:
     """
     Apply buffer operation to geometry.
 
@@ -118,29 +212,31 @@ def _apply_buffer(geometry: dict[str, Any], config: BufferConfig) -> dict[str, A
     - Negative buffer (erode): shrinks the geometry inward
     - Ring buffer: excludes the original geometry from the buffer
     - Buffer from center vs boundary
+
+    Projects the geometry to a local azimuthal equidistant CRS so that the
+    buffer distance is in metres (accurate), then reprojects the result back
+    to WGS84.
     """
-    geom = shape(geometry)
-    distance_deg = _meters_to_degrees(config.distance_m, geom.centroid.y)
+    cx, cy = geom.centroid.x, geom.centroid.y
+    to_local, to_wgs84 = _local_transformers(cx, cy)
+
+    geom_local = transform(to_local.transform, geom)
 
     if config.buffer_from == "center":
-        # Buffer from centroid
-        centroid = geom.centroid
-        buffered = centroid.buffer(abs(distance_deg))
+        buffered_local = geom_local.centroid.buffer(abs(config.distance_m))
     elif config.side is not None:
-        # One-sided buffer: symmetric buffer clipped to one side of the line
-        buffered = _one_sided_buffer(geom, abs(distance_deg), config.side)
+        buffered_local = _one_sided_buffer(geom_local, abs(config.distance_m), config.side)
     else:
-        # Buffer from boundary
-        buffered = geom.buffer(distance_deg)
+        buffered_local = geom_local.buffer(config.distance_m)
 
-    # Ring buffer: subtract original geometry
+    # Ring buffer: subtract original geometry (in local CRS)
     if config.ring_only and config.distance_m > 0:
-        buffered = buffered.difference(geom)
+        buffered_local = buffered_local.difference(geom_local)
 
-    if buffered.is_empty:
-        return geometry  # Fallback if erosion eliminates geometry
+    if buffered_local.is_empty:
+        return mapping(geom)  # Fallback if erosion eliminates geometry
 
-    return mapping(buffered)
+    return mapping(transform(to_wgs84.transform, buffered_local))
 
 
 def _collect_line_parts(geom: BaseGeometry) -> list[LineString]:
@@ -168,25 +264,27 @@ def _offset_coords(line: LineString, offset_dist: float) -> list[tuple[float, ..
     return list(offset.coords)
 
 
-def _one_sided_buffer(geom: BaseGeometry, distance_deg: float, side: str) -> BaseGeometry:
+def _one_sided_buffer(geom: BaseGeometry, distance_m: float, side: str) -> BaseGeometry:
     """
     Create a one-sided buffer by clipping a symmetric buffer to one side of a line.
 
-    Uses offset_curve to build a clipping polygon per segment, then intersects each
-    with the segment's buffer and unions the results. This avoids artifacts from
-    Shapely's single_sided=True on sinuous lines with large distances, and correctly
-    handles MultiLineString inputs (e.g. rivers stored as disconnected segments).
+    Operates on a geometry already projected to a local metric CRS so that
+    ``distance_m`` is in metres.  Uses offset_curve to build a clipping polygon
+    per segment, then intersects each with the segment's buffer and unions the
+    results. This avoids artifacts from Shapely's single_sided=True on sinuous
+    lines with large distances, and correctly handles MultiLineString inputs
+    (e.g. rivers stored as disconnected segments).
     """
     # offset_curve: positive = left, negative = right
-    offset_dist = distance_deg if side == "left" else -distance_deg
+    offset_dist = distance_m if side == "left" else -distance_m
 
     parts = _collect_line_parts(geom)
     if not parts:
-        return geom.buffer(distance_deg)
+        return geom.buffer(distance_m)
 
     clipped_parts: list[BaseGeometry] = []
     for part in parts:
-        part_buffer = part.buffer(distance_deg)
+        part_buffer = part.buffer(distance_m)
         off_coords = _offset_coords(part, offset_dist)
 
         if not off_coords:
@@ -202,7 +300,7 @@ def _one_sided_buffer(geom: BaseGeometry, distance_deg: float, side: str) -> Bas
 
 
 def _apply_directional(
-    geometry: dict[str, Any],
+    geom: BaseGeometry,
     config: BufferConfig,
     direction_degrees: float,
     sector_angle_degrees: float,
@@ -213,62 +311,33 @@ def _apply_directional(
     The sector extends outward from the centroid in the given direction.
     Convention: 0° = North, 90° = East, 180° = South, 270° = West (clockwise).
 
+    Arc points are computed geodesically using vectorized ``Geod.fwd`` so the
+    radius is accurate in metres regardless of latitude.
+
     Args:
-        geometry: Reference geometry.
+        geom: Reference geometry (Shapely, WGS84).
         config: Buffer config (distance_m used as sector radius).
         direction_degrees: Center direction of the sector (0=N, 90=E, etc.).
         sector_angle_degrees: Total angular width of the sector.
     """
-    geom = shape(geometry)
-    centroid = geom.centroid
-    cx, cy = centroid.x, centroid.y
+    cx, cy = geom.centroid.x, geom.centroid.y
 
-    radius_deg = _meters_to_degrees(config.distance_m, cy)
-    half_angle = sector_angle_degrees / 2
-
-    # Build sector as a polygon wedge
-    # Start angle and end angle (geographic: 0=N, clockwise)
-    start_angle = direction_degrees - half_angle
-    end_angle = direction_degrees + half_angle
-
-    # Generate arc points
     num_points = 36
-    points = [(cx, cy)]  # Center point
+    half_angle = sector_angle_degrees / 2
+    azimuths = [direction_degrees - half_angle + sector_angle_degrees * i / num_points for i in range(num_points + 1)]
 
-    for i in range(num_points + 1):
-        angle = start_angle + (end_angle - start_angle) * i / num_points
-        # Convert geographic angle to math angle
-        # Geographic: 0=N, 90=E (clockwise)
-        # Math: 0=E, 90=N (counterclockwise)
-        math_angle = math.radians(90 - angle)
-        px = cx + radius_deg * math.cos(math_angle)
-        py = cy + radius_deg * math.sin(math_angle)
-        points.append((px, py))
+    # Vectorized geodesic forward computation: all arc points in one call.
+    lons, lats, _ = _GEOD.fwd(
+        [cx] * (num_points + 1),
+        [cy] * (num_points + 1),
+        azimuths,
+        [config.distance_m] * (num_points + 1),
+    )
 
-    points.append((cx, cy))  # Close the polygon
-
+    points = [(cx, cy), *zip(lons, lats), (cx, cy)]
     sector = Polygon(points)
 
     if sector.is_empty or not sector.is_valid:
         sector = sector.buffer(0)  # Fix invalid geometry
 
     return mapping(sector)
-
-
-def _meters_to_degrees(meters: float, latitude: float) -> float:
-    """
-    Approximate conversion from meters to degrees at a given latitude.
-
-    This is a rough approximation suitable for buffer visualizations.
-    For precise work, use proper projection (e.g., UTM).
-
-    At the equator, 1° ≈ 111,320m. At higher latitudes, longitude degrees shrink.
-    We use the average of lat/lon degree sizes for a reasonable approximation.
-    """
-    # 1 degree latitude ≈ 111,320 meters (relatively constant)
-    meters_per_degree_lat = 111_320
-    # 1 degree longitude varies with latitude
-    meters_per_degree_lon = 111_320 * math.cos(math.radians(latitude))
-    # Average for a circular approximation
-    avg_meters_per_degree = (meters_per_degree_lat + meters_per_degree_lon) / 2
-    return meters / avg_meters_per_degree

--- a/tests/test_spatial.py
+++ b/tests/test_spatial.py
@@ -21,7 +21,7 @@ def test_buffer_positive():
     """Test positive circular buffer."""
     geom = {"type": "Point", "coordinates": [0, 0]}  # Null island
     relation = SpatialRelation(relation="near", category="buffer")
-    config = BufferConfig(distance_m=111320, buffer_from="center")  # ~1 degree at equator
+    config = BufferConfig(distance_m=111320, buffer_from="center", inferred=False)  # ~1 degree at equator
 
     result = apply_spatial_relation(geom, relation, config)
 
@@ -40,7 +40,7 @@ def test_buffer_negative_erosion():
 
     relation = SpatialRelation(relation="in_the_heart_of", category="buffer")
     # Erode by ~0.5 degrees (~55km)
-    config = BufferConfig(distance_m=-55000, buffer_from="boundary")
+    config = BufferConfig(distance_m=-55000, buffer_from="boundary", inferred=False)
 
     result = apply_spatial_relation(geom, relation, config)
 
@@ -62,7 +62,7 @@ def test_ring_buffer():
     poly = Polygon([(-0.5, -0.5), (0.5, -0.5), (0.5, 0.5), (-0.5, 0.5)])
     geom = mapping(poly)
 
-    config = BufferConfig(distance_m=100000, buffer_from="boundary", ring_only=True)
+    config = BufferConfig(distance_m=100000, buffer_from="boundary", ring_only=True, inferred=False)
 
     result = apply_spatial_relation(geom, relation, config)
 
@@ -76,7 +76,7 @@ def test_directional_sector():
     geom = {"type": "Point", "coordinates": [0, 0]}
     relation = SpatialRelation(relation="north_of", category="directional")
     # North sector (0 degrees), 90 degree width
-    config = BufferConfig(distance_m=100000, buffer_from="center")
+    config = BufferConfig(distance_m=100000, buffer_from="center", inferred=False)
 
     # Mocking the spatial config lookup inside apply_spatial_relation requires mocking
     # SpatialRelationConfig. Or we can rely on defaults if we didn't mock it?
@@ -98,7 +98,7 @@ def test_left_side_buffer():
     geom = mapping(line)
 
     relation = SpatialRelation(relation="left_bank", category="buffer")
-    config = BufferConfig(distance_m=111320, buffer_from="boundary", side="left")  # ~1 degree
+    config = BufferConfig(distance_m=111320, buffer_from="boundary", side="left", inferred=False)  # ~1 degree
 
     result = apply_spatial_relation(geom, relation, config)
 
@@ -116,7 +116,7 @@ def test_right_side_buffer():
     geom = mapping(line)
 
     relation = SpatialRelation(relation="right_bank", category="buffer")
-    config = BufferConfig(distance_m=111320, buffer_from="boundary", side="right")  # ~1 degree
+    config = BufferConfig(distance_m=111320, buffer_from="boundary", side="right", inferred=False)  # ~1 degree
 
     result = apply_spatial_relation(geom, relation, config)
 
@@ -156,7 +156,7 @@ def test_side_none_symmetric_buffer():
     geom = mapping(line)
 
     relation = SpatialRelation(relation="along", category="buffer")
-    config = BufferConfig(distance_m=111320, buffer_from="boundary", side=None)  # ~1 degree
+    config = BufferConfig(distance_m=111320, buffer_from="boundary", side=None, inferred=False)  # ~1 degree
 
     result = apply_spatial_relation(geom, relation, config)
 
@@ -176,7 +176,7 @@ def test_list_input_buffer_union():
     seg2 = {"type": "LineString", "coordinates": [[1.0, 0.0], [2.0, 0.0]]}
     full = {"type": "LineString", "coordinates": [[0.0, 0.0], [1.0, 0.0], [2.0, 0.0]]}
     relation = SpatialRelation(relation="along", category="buffer")
-    config = BufferConfig(distance_m=111320, buffer_from="boundary")
+    config = BufferConfig(distance_m=111320, buffer_from="boundary", inferred=False)
 
     result = shape(apply_spatial_relation([seg1, seg2], relation, config))
     reference = shape(apply_spatial_relation(full, relation, config))
@@ -189,7 +189,7 @@ def test_list_input_single_matches_dict():
     """Single-element list gives the same result as passing the dict directly."""
     geom = {"type": "Point", "coordinates": [0.0, 0.0]}
     relation = SpatialRelation(relation="near", category="buffer")
-    config = BufferConfig(distance_m=111320, buffer_from="center")
+    config = BufferConfig(distance_m=111320, buffer_from="center", inferred=False)
 
     assert shape(apply_spatial_relation(geom, relation, config)).equals_exact(
         shape(apply_spatial_relation([geom], relation, config)), tolerance=1e-10
@@ -201,7 +201,7 @@ def test_list_input_empty_raises():
     import pytest
 
     relation = SpatialRelation(relation="near", category="buffer")
-    config = BufferConfig(distance_m=5000, buffer_from="center")
+    config = BufferConfig(distance_m=5000, buffer_from="center", inferred=False)
     with pytest.raises(ValueError, match="empty"):
         apply_spatial_relation([], relation, config)
 


### PR DESCRIPTION
- Integrate area-based buffer distance inference directly in apply_spatial_relation(): when buffer_config.inferred=True and no explicit_distance, compute geodesic area of the reference geometry (via pyproj.Geod) and select distance from brackets (500m / 1500m / 5000m / 15000m for proximity; -200m to -2000m for erosion)
- Replace degree-math with geodesically accurate operations throughout spatial.py: buffer projects to local azimuthal equidistant CRS (pyproj.Transformer) before buffering in metres; directional arc points computed via Geod.fwd arrays
- Optimise apply_spatial_relation: geometry parsed to Shapely once at top, removing double shape() call; _apply_containment eliminated; dispatcher functions receive BaseGeometry directly; arc computation vectorised with single array Geod.fwd call
- Narrow return type of _to_json_value in ign_bdcarto.py to str|float|int|bool|None
- Improve type annotations in postgis.py: Connection, Row, types.ModuleType instead of Any
- Simplify prompts.py: remove boilerplate lines, collapse distance-inference section
- Update ARCHITECTURE.md: area-bracket table, geodesic ops description
- Fix test_spatial.py: add inferred=False to explicit-distance BufferConfig calls