### PR TITLE
chore: replace dict[str, Any] with geojson.Feature and GeoJsonGeometry types

### DIFF
--- a/etter/datasources/composite.py
+++ b/etter/datasources/composite.py
@@ -5,7 +5,7 @@ Queries are forwarded to every registered source and results are merged,
 deduplicating by (name, type) while preserving original ordering.
 """
 
-from typing import Any
+from geojson import Feature
 
 from .protocol import GeoDataSource
 
@@ -42,7 +42,7 @@ class CompositeDataSource:
         name: str,
         type: str | None = None,
         max_results: int = 10,
-    ) -> list[dict[str, Any]]:
+    ) -> list[Feature]:
         """
         Search all registered sources and return merged.
 
@@ -54,7 +54,7 @@ class CompositeDataSource:
         Returns:
             List of GeoJSON Feature dicts, merged from all sources.
         """
-        merged: list[dict[str, Any]] = []
+        merged: list[Feature] = []
 
         for source in self._sources:
             for feature in source.search(name, type=type, max_results=max_results):
@@ -64,7 +64,7 @@ class CompositeDataSource:
 
         return merged
 
-    def get_by_id(self, feature_id: str) -> dict[str, Any] | None:
+    def get_by_id(self, feature_id: str) -> Feature | None:
         """
         Get a feature by ID, trying each source in order.
 

--- a/etter/datasources/ign_bdcarto.py
+++ b/etter/datasources/ign_bdcarto.py
@@ -33,6 +33,7 @@ from typing import Any, cast
 
 import geopandas as gpd
 import pandas as pd
+from geojson import Feature
 from rapidfuzz import fuzz
 from shapely.geometry import mapping
 
@@ -372,7 +373,7 @@ class IGNBDCartoSource:
                     self._name_index[key] = []
                 self._name_index[key].append(idx)
 
-    def _row_to_feature(self, idx: int) -> dict[str, Any]:
+    def _row_to_feature(self, idx: int) -> Feature:
         """Convert a GeoDataFrame row to a GeoJSON Feature dict (WGS84)."""
         assert self._gdf is not None
         row = self._gdf.iloc[idx]
@@ -402,20 +403,14 @@ class IGNBDCartoSource:
                 if val is not None:
                     properties[col] = val
 
-        return {
-            "type": "Feature",
-            "id": feature_id,
-            "geometry": geometry,
-            "bbox": bbox,
-            "properties": properties,
-        }
+        return Feature(geometry=geometry, properties=properties, id=feature_id, bbox=bbox)
 
     def search(
         self,
         name: str,
         type: str | None = None,
         max_results: int = 10,
-    ) -> list[dict[str, Any]]:
+    ) -> list[Feature]:
         """
         Search for geographic features by name.
 
@@ -470,7 +465,7 @@ class IGNBDCartoSource:
         matches.sort(key=lambda x: x[1], reverse=True)
         return [idx for idx, _ in matches]
 
-    def get_by_id(self, feature_id: str) -> dict[str, Any] | None:
+    def get_by_id(self, feature_id: str) -> Feature | None:
         """
         Get a feature by its ``cleabs`` identifier or row index.
 

--- a/etter/datasources/location_types.py
+++ b/etter/datasources/location_types.py
@@ -13,8 +13,9 @@ of type "lake", "river", "pond", etc.
 from __future__ import annotations
 
 from collections import defaultdict
-from typing import Any, Literal
+from typing import Literal
 
+from geojson import Feature
 from shapely.geometry import mapping, shape
 from shapely.ops import unary_union
 
@@ -349,7 +350,7 @@ MERGE_TYPES: frozenset[str] = frozenset(
 )
 
 
-def merge_segments(features: list[dict[str, Any]]) -> list[dict[str, Any]]:
+def merge_segments(features: list[Feature]) -> list[Feature]:
     """
     Merge features that share the same (name, type) by unioning their geometries,
     but only for types listed in ``MERGE_TYPES``.
@@ -361,22 +362,27 @@ def merge_segments(features: list[dict[str, Any]]) -> list[dict[str, Any]]:
     excluded because two places with the same name are distinct and must not be
     conflated.
     """
-    groups: dict[tuple[str, str], list[dict[str, Any]]] = defaultdict(list)
+    groups: dict[tuple[str, str], list[Feature]] = defaultdict(list)
     for f in features:
         props = f.get("properties", {})
         key = (str(props.get("name", "")), str(props.get("type", "")))
         groups[key].append(f)
 
-    merged: list[dict[str, Any]] = []
+    merged: list[Feature] = []
     for (_name, ftype), group_features in groups.items():
         if len(group_features) == 1 or ftype not in MERGE_TYPES:
             merged.extend(group_features)
         else:
             geoms = [shape(f["geometry"]) for f in group_features if f.get("geometry") and f["geometry"].get("type")]
             combined = unary_union(geoms)
-            base = dict(group_features[0].items())
-            base["geometry"] = mapping(combined)
+            ref = group_features[0]
             bounds = combined.bounds
-            base["bbox"] = tuple(bounds) if bounds else None
-            merged.append(base)
+            merged.append(
+                Feature(
+                    geometry=mapping(combined),
+                    properties=ref.get("properties", {}),
+                    id=ref.get("id"),
+                    bbox=tuple(bounds) if bounds else None,
+                )
+            )
     return merged

--- a/etter/datasources/postgis.py
+++ b/etter/datasources/postgis.py
@@ -29,6 +29,8 @@ import logging
 import unicodedata
 from typing import TYPE_CHECKING, Any
 
+from geojson import Feature
+
 from .location_types import TypeMap, get_matching_types, merge_segments
 
 logger = logging.getLogger(__name__)
@@ -223,7 +225,7 @@ class PostGISDataSource:
             return None
         return self._raw_to_normalized.get(raw_type, raw_type)
 
-    def _row_to_feature(self, row: Row) -> dict[str, Any]:
+    def _row_to_feature(self, row: Row) -> Feature:
         """Convert a SQLAlchemy Row to a GeoJSON Feature dict."""
         feature_id = str(row.id)
         name = str(row.name)
@@ -244,13 +246,7 @@ class PostGISDataSource:
             "confidence": 1.0,
         }
 
-        return {
-            "type": "Feature",
-            "id": feature_id,
-            "geometry": geometry,
-            "bbox": bbox,
-            "properties": properties,
-        }
+        return Feature(geometry=geometry, properties=properties, id=feature_id, bbox=bbox)
 
     def _build_select_columns(self) -> str:
         """Build the SELECT column list as a SQL fragment."""
@@ -266,7 +262,7 @@ class PostGISDataSource:
         name: str,
         type: str | None = None,
         max_results: int = 10,
-    ) -> list[dict[str, Any]]:
+    ) -> list[Feature]:
         """
         Search for geographic features by name.
 
@@ -342,7 +338,7 @@ class PostGISDataSource:
         name: str,
         type_filter: list[str] | None,
         fetch_limit: int,
-    ) -> list[dict[str, Any]]:
+    ) -> list[Feature]:
         """
         Exact accent- and case-insensitive search.
 
@@ -378,7 +374,7 @@ class PostGISDataSource:
         name: str,
         type_filter: list[str] | None,
         fetch_limit: int,
-    ) -> list[dict[str, Any]]:
+    ) -> list[Feature]:
         """Case-insensitive substring fallback using ``ILIKE '%name%'``.
 
         When the ``unaccent`` extension is available, both the stored name column
@@ -415,7 +411,7 @@ class PostGISDataSource:
         name: str,
         type_filter: list[str] | None,
         fetch_limit: int,
-    ) -> list[dict[str, Any]]:
+    ) -> list[Feature]:
         """Fuzzy fallback using pg_trgm similarity (if extension is available)."""
         if not self._check_trgm(conn):
             logger.warning(
@@ -451,7 +447,7 @@ class PostGISDataSource:
             logger.exception("Fuzzy search failed for %r", name)
             return []
 
-    def get_by_id(self, feature_id: str) -> dict[str, Any] | None:
+    def get_by_id(self, feature_id: str) -> Feature | None:
         """
         Get a specific feature by its unique identifier.
 

--- a/etter/datasources/protocol.py
+++ b/etter/datasources/protocol.py
@@ -5,7 +5,9 @@ Any class implementing this Protocol can be used as a datasource,
 without needing to inherit from a base class (structural typing).
 """
 
-from typing import Any, Protocol
+from typing import Protocol
+
+from geojson import Feature
 
 
 class GeoDataSource(Protocol):
@@ -35,7 +37,7 @@ class GeoDataSource(Protocol):
         name: str,
         type: str | None = None,
         max_results: int = 10,
-    ) -> list[dict[str, Any]]:
+    ) -> list[Feature]:
         """
         Search for geographic features by name.
 
@@ -52,7 +54,7 @@ class GeoDataSource(Protocol):
         """
         ...
 
-    def get_by_id(self, feature_id: str) -> dict[str, Any] | None:
+    def get_by_id(self, feature_id: str) -> Feature | None:
         """
         Get a specific feature by its unique identifier.
 

--- a/etter/datasources/swissnames3d.py
+++ b/etter/datasources/swissnames3d.py
@@ -13,6 +13,7 @@ from typing import Any
 
 import geopandas as gpd
 import pyproj
+from geojson import Feature
 from rapidfuzz import fuzz
 from shapely import force_2d
 from shapely.geometry import mapping
@@ -272,7 +273,7 @@ class SwissNames3DSource:
                 return candidate
         return None
 
-    def _row_to_feature(self, idx: int) -> dict[str, Any]:
+    def _row_to_feature(self, idx: int) -> Feature:
         """Convert a GeoDataFrame row to a GeoJSON Feature dict with WGS84 geometry."""
         assert self._gdf is not None
         row = self._gdf.iloc[idx]
@@ -321,20 +322,14 @@ class SwissNames3DSource:
                 if val is not None and str(val) != "nan":
                     properties[col] = val
 
-        return {
-            "type": "Feature",
-            "id": feature_id,
-            "geometry": geometry,
-            "bbox": bbox,
-            "properties": properties,
-        }
+        return Feature(geometry=geometry, properties=properties, id=feature_id, bbox=bbox)
 
     def search(
         self,
         name: str,
         type: str | None = None,
         max_results: int = 10,
-    ) -> list[dict[str, Any]]:
+    ) -> list[Feature]:
         """
         Search for geographic features by name.
 
@@ -412,7 +407,7 @@ class SwissNames3DSource:
         matches.sort(key=lambda x: x[1], reverse=True)
         return [idx for idx, _ in matches]
 
-    def get_by_id(self, feature_id: str) -> dict[str, Any] | None:
+    def get_by_id(self, feature_id: str) -> Feature | None:
         """
         Get a specific feature by its unique identifier.
 

--- a/etter/geometry_format.py
+++ b/etter/geometry_format.py
@@ -2,14 +2,12 @@
 Utilities for converting GeoJSON geometry dicts to alternative output formats (WKT, WKB).
 """
 
-from typing import Any
-
 from shapely.geometry import shape
 
-from .models import GeometryFormat
+from .models import Feature, GeoJsonGeometry, GeometryFormat
 
 
-def convert_geometry(geometry: dict[str, Any], fmt: GeometryFormat) -> dict[str, Any] | str:
+def convert_geometry(geometry: GeoJsonGeometry, fmt: GeometryFormat) -> GeoJsonGeometry | str:
     """
     Convert a GeoJSON geometry dict to the requested format.
 
@@ -29,7 +27,7 @@ def convert_geometry(geometry: dict[str, Any], fmt: GeometryFormat) -> dict[str,
     return geom.wkb_hex
 
 
-def convert_feature_geometry(feature: dict[str, Any], fmt: GeometryFormat) -> dict[str, Any]:
+def convert_feature_geometry(feature: Feature, fmt: GeometryFormat) -> Feature | dict:
     """
     Return a copy of a GeoJSON Feature dict with its geometry converted to the requested format.
 
@@ -39,6 +37,7 @@ def convert_feature_geometry(feature: dict[str, Any], fmt: GeometryFormat) -> di
 
     Returns:
         A new dict identical to the input except the "geometry" value is converted.
+        Returns a Feature when fmt is "geojson"; a plain dict otherwise (geometry becomes a string).
     """
     if fmt == "geojson":
         return feature

--- a/etter/models.py
+++ b/etter/models.py
@@ -2,9 +2,14 @@
 Pydantic models for structured geographic query representation.
 """
 
-from typing import Annotated, Literal
+from typing import Annotated, Any, Literal, TypeAlias
 
+from geojson import Feature
 from pydantic import BaseModel, Field, model_validator
+
+GeoJsonGeometry: TypeAlias = dict[str, Any]
+
+__all__ = ["Feature", "GeoJsonGeometry"]
 
 ConfidenceLevel = Annotated[float, Field(ge=0.0, le=1.0, description="Confidence score between 0 and 1")]
 

--- a/etter/spatial.py
+++ b/etter/spatial.py
@@ -6,8 +6,6 @@ All inputs and outputs are GeoJSON dicts in WGS84 (EPSG:4326).
 Shapely is used internally for geometry operations.
 """
 
-from typing import Any
-
 from pyproj import Geod, Transformer
 from shapely.geometry import MultiLineString, box, mapping, shape
 from shapely.geometry.base import BaseGeometry
@@ -16,7 +14,7 @@ from shapely.geometry.polygon import Polygon
 from shapely.ops import linemerge, transform, unary_union
 
 from .geometry_format import convert_geometry
-from .models import BufferConfig, GeometryFormat, SpatialRelation
+from .models import BufferConfig, GeoJsonGeometry, GeometryFormat, SpatialRelation
 from .spatial_config import SpatialRelationConfig
 
 _DEFAULT_SPATIAL_CONFIG = SpatialRelationConfig()  # Module-level singleton for default spatial relation configuration.
@@ -110,12 +108,12 @@ def _refine_buffer_config(
 
 
 def apply_spatial_relation(
-    geometry: dict[str, Any] | list[dict[str, Any]],
+    geometry: GeoJsonGeometry | list[GeoJsonGeometry],
     relation: SpatialRelation,
     buffer_config: BufferConfig | None = None,
     spatial_config: SpatialRelationConfig | None = None,
     geometry_format: GeometryFormat = "geojson",
-) -> dict[str, Any] | str:
+) -> GeoJsonGeometry | str:
     """Transform one or more reference geometries according to a spatial relation.
 
     A list of geometries is unioned into one before the transformation, so that
@@ -141,7 +139,7 @@ def apply_spatial_relation(
         if not geometry:
             raise ValueError("geometry list must not be empty")
         geom = unary_union([shape(g) for g in geometry])
-        geom_dict: dict[str, Any] = mapping(geom)
+        geom_dict: GeoJsonGeometry = mapping(geom)
     else:
         geom = shape(geometry)
         geom_dict = geometry
@@ -175,7 +173,7 @@ def apply_spatial_relation(
     return convert_geometry(result, geometry_format)
 
 
-def _apply_clipping(geom: BaseGeometry, clip_direction: str) -> dict[str, Any]:
+def _apply_clipping(geom: BaseGeometry, clip_direction: str) -> GeoJsonGeometry:
     """
     Clip a geometry to a directional half-plane using its bounding box midpoint.
 
@@ -203,7 +201,7 @@ def _apply_clipping(geom: BaseGeometry, clip_direction: str) -> dict[str, Any]:
     return mapping(clipped)
 
 
-def _apply_buffer(geom: BaseGeometry, config: BufferConfig) -> dict[str, Any]:
+def _apply_buffer(geom: BaseGeometry, config: BufferConfig) -> GeoJsonGeometry:
     """
     Apply buffer operation to geometry.
 
@@ -304,7 +302,7 @@ def _apply_directional(
     config: BufferConfig,
     direction_degrees: float,
     sector_angle_degrees: float,
-) -> dict[str, Any]:
+) -> GeoJsonGeometry:
     """
     Create a directional sector wedge from the geometry centroid.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "pyproj>=3.7",
     "geopandas>=1.1",
     "rapidfuzz>=3.14",
+    "geojson>=3.2",
 ]
 
 [project.urls]
@@ -66,7 +67,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.ruff]
 line-length = 120
-target-version = "py313"
+target-version = "py310"
 
 [tool.ruff.lint]
 select = ["F", "I", "E", "W", "UP", "C4", "ARG"]

--- a/uv.lock
+++ b/uv.lock
@@ -459,6 +459,7 @@ name = "etter"
 version = "0.4.1"
 source = { editable = "." }
 dependencies = [
+    { name = "geojson" },
     { name = "geopandas" },
     { name = "langchain" },
     { name = "pydantic" },
@@ -497,6 +498,7 @@ requires-dist = [
     { name = "etter", extras = ["postgis"], marker = "extra == 'dev'" },
     { name = "fastapi", marker = "extra == 'dev'", specifier = ">=0.135" },
     { name = "geoalchemy2", marker = "extra == 'postgis'", specifier = ">=0.15" },
+    { name = "geojson", specifier = ">=3.2" },
     { name = "geopandas", specifier = ">=1.1" },
     { name = "langchain", specifier = ">=1.2" },
     { name = "langchain-openai", marker = "extra == 'dev'", specifier = ">=1.1.14" },
@@ -559,6 +561,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f1/3e/8b6b15cd6a68bb4472ad865e8ecc83b010f1673a22834a52fa479cabf639/geoalchemy2-0.19.0.tar.gz", hash = "sha256:c88be59cdb90af9d74278bdd33a5f58acb23859f0f1380726593eed0f343f4a8", size = 240220, upload-time = "2026-04-12T21:02:16.544Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/35/78/0d5918bea58179dc7a6b724c097b3d972f875328460503f74521c46283bc/geoalchemy2-0.19.0-py3-none-any.whl", hash = "sha256:878a5859e23ae632fe20ea35412cda40f50c94fa69c9242587574941e4d4ec32", size = 81145, upload-time = "2026-04-12T21:02:15.337Z" },
+]
+
+[[package]]
+name = "geojson"
+version = "3.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/5a/33e761df75c732fcea94aaf01f993d823138581d10c91133da58bc231e63/geojson-3.2.0.tar.gz", hash = "sha256:b860baba1e8c6f71f8f5f6e3949a694daccf40820fa8f138b3f712bd85804903", size = 24574, upload-time = "2024-12-21T19:35:29.835Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/a7fa2d650602731c90e0a86279841b4586e14228199e8c09165ba4863e29/geojson-3.2.0-py3-none-any.whl", hash = "sha256:69d14156469e13c79479672eafae7b37e2dcd19bdfd77b53f74fa8fe29910b52", size = 15040, upload-time = "2024-12-21T19:37:02.149Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Add geojson>=3.2 as a dependency and introduce typed GeoJSON annotations throughout the codebase. Feature-returning methods now construct geojson.Feature objects; geometry dicts are annotated with GeoJsonGeometry (TypeAlias). Suppresses ruff UP040 since the project targets Python 3.10 where the type keyword is unavailable.