### PR TITLE
perf: optimize geopandas/Shapely usage across datasources and spatial operations

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,3 +14,13 @@ repos:
         args:
           - --fix
       - id: ruff-format
+  - repo: local
+    hooks:
+      - id: ty
+        name: ty
+        language: system
+        entry: bash
+        files: etter/
+        types: [python]
+        args: [-c, 'uv run ty check etter/']
+        pass_filenames: false

--- a/demo/main.py
+++ b/demo/main.py
@@ -1,3 +1,4 @@
+import asyncio
 import contextlib
 import json
 import logging
@@ -31,6 +32,7 @@ geo_mcp = FastMCP("etter MCP Server", stateless_http=True, json_response=True)
 
 @contextlib.asynccontextmanager
 async def lifespan(_app: FastAPI):
+    await asyncio.to_thread(datasource.preload)
     async with geo_mcp.session_manager.run():
         yield
 

--- a/etter/datasources/composite.py
+++ b/etter/datasources/composite.py
@@ -5,9 +5,16 @@ Queries are forwarded to every registered source and results are merged,
 deduplicating by (name, type) while preserving original ordering.
 """
 
+from typing import Protocol, runtime_checkable
+
 from geojson import Feature
 
 from .protocol import GeoDataSource
+
+
+@runtime_checkable
+class _Preloadable(Protocol):
+    def preload(self) -> None: ...
 
 
 class CompositeDataSource:
@@ -34,6 +41,12 @@ class CompositeDataSource:
         if not sources:
             raise ValueError("At least one datasource is required.")
         self._sources: list[GeoDataSource] = list(sources)
+
+    def preload(self) -> None:
+        """Eagerly load all sources that support preloading."""
+        for source in self._sources:
+            if isinstance(source, _Preloadable):
+                source.preload()
 
     # Public API (mirrors GeoDataSource protocol)
 

--- a/etter/datasources/ign_bdcarto.py
+++ b/etter/datasources/ign_bdcarto.py
@@ -241,26 +241,24 @@ def _to_json_value(val: Any) -> str | float | int | bool | None:
     return val
 
 
-def _commune_type(row: pd.Series) -> str:
-    """Derive municipality vs. city from chef-lieu boolean flags."""
-    for flag in ("capitale_d_etat", "chef_lieu_de_region", "chef_lieu_de_departement", "chef_lieu_d_arrondissement"):
-        if flag in row.index and str(row[flag]).strip().lower() == "true":
-            return "city"
-    return "municipality"
-
-
-def _derive_type(row: pd.Series, cfg: dict[str, Any]) -> str:
-    """Return the normalized type for a single row given its layer config."""
+def _assign_type_col(gdf: gpd.GeoDataFrame, cfg: dict[str, Any]) -> None:
+    """Assign the _TYPE_COL column using vectorized operations."""
     if cfg.get("commune_flags"):
-        return _commune_type(row)
-    if cfg.get("fixed_type"):
-        return cfg["fixed_type"]
-    type_col: str | None = cfg.get("type_col")
-    type_map: dict[str, str] | None = cfg.get("type_map")
-    if type_col and type_map:
-        raw = str(row.get(type_col, "")) if pd.notna(row.get(type_col)) else ""
-        return type_map.get(raw, "unknown")
-    return "unknown"
+        flags = ["capitale_d_etat", "chef_lieu_de_region", "chef_lieu_de_departement", "chef_lieu_d_arrondissement"]
+        present = [f for f in flags if f in gdf.columns]
+        if present:
+            is_city = pd.concat([gdf[f].astype(str).str.strip().str.lower() == "true" for f in present], axis=1).any(
+                axis=1
+            )
+        else:
+            is_city = pd.Series(False, index=gdf.index)
+        gdf[_TYPE_COL] = is_city.map({True: "city", False: "municipality"})
+    elif fixed := cfg.get("fixed_type"):
+        gdf[_TYPE_COL] = fixed
+    elif (type_col := cfg.get("type_col")) and (type_map := cfg.get("type_map")):
+        gdf[_TYPE_COL] = gdf[type_col].astype(str).map(type_map).fillna("unknown")
+    else:
+        gdf[_TYPE_COL] = "unknown"
 
 
 class IGNBDCartoSource:
@@ -292,6 +290,11 @@ class IGNBDCartoSource:
         self._data_path = Path(data_path)
         self._gdf: gpd.GeoDataFrame | None = None
         self._name_index: dict[str, list[int]] = {}
+        self._token_index: dict[str, set[str]] = {}
+
+    def preload(self) -> None:
+        """Eagerly load data. Call at startup to avoid first-query latency."""
+        self._ensure_loaded()
 
     def _ensure_loaded(self) -> None:
         if self._gdf is not None:
@@ -303,6 +306,7 @@ class IGNBDCartoSource:
             self._gdf = self._load_from_directory()
         else:
             self._gdf = self._load_from_file(self._data_path)
+
         self._build_name_index()
 
     def _load_from_file(self, path: Path) -> gpd.GeoDataFrame:
@@ -320,7 +324,7 @@ class IGNBDCartoSource:
             if name_col not in rows.columns:
                 continue
             rows[_NAME_COL] = rows[name_col].astype(str)
-            rows[_TYPE_COL] = rows.apply(lambda row, c=cfg: _derive_type(row, c), axis=1)
+            _assign_type_col(rows, cfg)
             rows = rows.to_crs("EPSG:4326")
             gdfs.append(rows)
 
@@ -346,7 +350,7 @@ class IGNBDCartoSource:
                 continue
 
             gdf[_NAME_COL] = gdf[name_col].astype(str)
-            gdf[_TYPE_COL] = gdf.apply(lambda row, c=cfg: _derive_type(row, c), axis=1)
+            _assign_type_col(gdf, cfg)
             gdf["_layer"] = layer_name
             gdf = gdf.to_crs("EPSG:4326")
 
@@ -362,9 +366,10 @@ class IGNBDCartoSource:
         return gpd.GeoDataFrame(combined, crs="EPSG:4326", geometry="geometry")
 
     def _build_name_index(self) -> None:
-        """Build normalized name → row indices lookup (with article-stripped variants)."""
+        """Build normalized name → row indices and token → candidate names indexes."""
         assert self._gdf is not None
         self._name_index = {}
+        self._token_index = {}
         for idx, name in enumerate(self._gdf[_NAME_COL]):
             if not isinstance(name, str) or not name.strip() or name == "nan":
                 continue
@@ -372,6 +377,10 @@ class IGNBDCartoSource:
                 if key not in self._name_index:
                     self._name_index[key] = []
                 self._name_index[key].append(idx)
+                for token in key.split():
+                    if token not in self._token_index:
+                        self._token_index[token] = set()
+                    self._token_index[token].add(key)
 
     def _row_to_feature(self, idx: int) -> Feature:
         """Convert a GeoDataFrame row to a GeoJSON Feature dict (WGS84)."""
@@ -451,16 +460,17 @@ class IGNBDCartoSource:
         return features[:max_results]
 
     def _fuzzy_search(self, normalized: str, threshold: float = 75.0) -> list[int]:
-        """Token-overlap + token_set_ratio fuzzy search."""
-        matches: list[tuple[int, float]] = []
-        query_tokens = set(normalized.split())
+        """Fuzzy search using a token inverted index for fast candidate pre-filtering."""
+        candidates: set[str] = set()
+        for token in normalized.split():
+            candidates |= self._token_index.get(token, set())
 
-        for indexed_name, indices in self._name_index.items():
-            if query_tokens & set(indexed_name.split()):
-                score = fuzz.token_set_ratio(normalized, indexed_name)
-                if score >= threshold:
-                    for idx in indices:
-                        matches.append((idx, score))
+        matches: list[tuple[int, float]] = []
+        for name in candidates:
+            score = fuzz.token_set_ratio(normalized, name)
+            if score >= threshold:
+                for idx in self._name_index[name]:
+                    matches.append((idx, score))
 
         matches.sort(key=lambda x: x[1], reverse=True)
         return [idx for idx, _ in matches]

--- a/etter/datasources/swissnames3d.py
+++ b/etter/datasources/swissnames3d.py
@@ -12,17 +12,13 @@ from pathlib import Path
 from typing import Any
 
 import geopandas as gpd
-import pyproj
+import pandas as pd
 from geojson import Feature
 from rapidfuzz import fuzz
 from shapely import force_2d
 from shapely.geometry import mapping
-from shapely.ops import transform as shapely_transform
 
 from .location_types import TypeMap, get_matching_types
-
-# CH1903+ (LV95) to WGS84 transformer - data is assumed to always be in EPSG:2056
-_TRANSFORMER = pyproj.Transformer.from_crs("EPSG:2056", "EPSG:4326", always_xy=True)
 
 # Map normalized, grouped types to their OBJEKTART values.
 # Each type groups related OBJEKTART values (e.g., lake groups: See, Seeteil).
@@ -186,6 +182,15 @@ class SwissNames3DSource:
         self._layer = layer
         self._gdf: gpd.GeoDataFrame | None = None
         self._name_index: dict[str, list[int]] = {}
+        self._token_index: dict[str, set[str]] = {}
+        self._name_col: str = ""
+        self._type_col: str | None = None
+        self._id_col: str | None = None
+        self._extra_cols: list[str] = []
+
+    def preload(self) -> None:
+        """Eagerly load data. Call at startup to avoid first-query latency."""
+        self._ensure_loaded()
 
     def _ensure_loaded(self) -> None:
         """Load data lazily on first access."""
@@ -195,15 +200,33 @@ class SwissNames3DSource:
 
     def _load_data(self) -> None:
         """Load SwissNames3D data and build the name index."""
-        # Check if data_path is a directory
         if self._data_path.is_dir():
             self._load_from_directory()
         else:
-            # Load single file
             kwargs: dict[str, Any] = {}
             if self._layer is not None:
                 kwargs["layer"] = self._layer
             self._gdf = gpd.read_file(str(self._data_path), **kwargs)
+
+        assert self._gdf is not None
+
+        # Drop Z coordinates once — vectorized; the source has LN02 height and
+        # single_sided buffers reject 3D geometries
+        self._gdf.geometry = force_2d(self._gdf.geometry.values)
+
+        # Reproject to WGS84 once — avoids per-query coordinate transform
+        self._gdf = self._gdf.to_crs("EPSG:4326")
+
+        # Cache column names once — reused on every _row_to_feature() call
+        self._name_col = self._detect_name_column()
+        self._type_col = self._detect_type_column()
+        self._id_col = self._detect_id_column()
+        skip = {self._name_col, "geometry"}
+        if self._type_col:
+            skip.add(self._type_col)
+        if self._id_col:
+            skip.add(self._id_col)
+        self._extra_cols = [c for c in self._gdf.columns if c not in skip]
 
         self._build_name_index()
 
@@ -231,46 +254,49 @@ class SwissNames3DSource:
 
         # Keep only common columns and concatenate
         gdfs_filtered = [gdf[sorted(common_cols)] for gdf in gdfs]
-        self._gdf = gpd.GeoDataFrame(
-            gpd.pd.concat(gdfs_filtered, ignore_index=True), crs=gdfs[0].crs, geometry="geometry"
-        )
+        self._gdf = gpd.GeoDataFrame(pd.concat(gdfs_filtered, ignore_index=True), crs=gdfs[0].crs, geometry="geometry")
 
     def _build_name_index(self) -> None:
-        """Build a normalized name → row indices lookup for fast search."""
+        """Build normalized name → row indices and token → candidate names indexes."""
         assert self._gdf is not None
         self._name_index = {}
+        self._token_index = {}
 
-        name_col = self._detect_name_column()
-        for idx, name in enumerate(self._gdf[name_col]):
+        for idx, name in enumerate(self._gdf[self._name_col]):
             if not isinstance(name, str) or not name.strip():
                 continue
             normalized = _normalize_name(name)
             if normalized not in self._name_index:
                 self._name_index[normalized] = []
             self._name_index[normalized].append(idx)
+            for token in normalized.split():
+                if token not in self._token_index:
+                    self._token_index[token] = set()
+                self._token_index[token].add(normalized)
 
     def _detect_name_column(self) -> str:
         """Detect the name column in the data."""
         assert self._gdf is not None
-        for candidate in ("NAME", "name", "Name", "BEZEICHNUNG"):
-            if candidate in self._gdf.columns:
-                return candidate
+        for col in self._gdf.columns:
+            if col.upper() in ("NAME", "BEZEICHNUNG"):
+                return col
         raise ValueError(f"Cannot find name column in data. Available columns: {list(self._gdf.columns)}")
 
     def _detect_type_column(self) -> str | None:
         """Detect the feature type column in the data."""
         assert self._gdf is not None
-        for candidate in ("OBJEKTART", "objektart", "Objektart"):
-            if candidate in self._gdf.columns:
-                return candidate
+        for col in self._gdf.columns:
+            if col.upper() == "OBJEKTART":
+                return col
         return None
 
     def _detect_id_column(self) -> str | None:
         """Detect the unique ID column in the data."""
         assert self._gdf is not None
-        for candidate in ("UUID", "uuid", "FID", "OBJECTID", "id"):
-            if candidate in self._gdf.columns:
-                return candidate
+        for candidate in ("UUID", "FID", "OBJECTID", "ID"):
+            for col in self._gdf.columns:
+                if col.upper() == candidate:
+                    return col
         return None
 
     def _row_to_feature(self, idx: int) -> Feature:
@@ -278,49 +304,32 @@ class SwissNames3DSource:
         assert self._gdf is not None
         row = self._gdf.iloc[idx]
 
-        # Get name
-        name_col = self._detect_name_column()
-        name = str(row[name_col])
+        name = str(row[self._name_col])
 
-        # Get type
-        type_col = self._detect_type_column()
-        raw_type = str(row[type_col]) if type_col and row.get(type_col) else "unknown"
+        raw_type = str(row[self._type_col]) if self._type_col and row.get(self._type_col) else "unknown"
         normalized_type = _objektart_to_type(raw_type)
 
-        # Get ID
-        id_col = self._detect_id_column()
-        feature_id = str(row[id_col]) if id_col and row.get(id_col) else str(idx)
+        feature_id = str(row[self._id_col]) if self._id_col and row.get(self._id_col) else str(idx)
 
-        # Convert geometry to WGS84 GeoJSON
+        # Geometry is already in WGS84 (2D) — pre-converted at load time
         geom = row.geometry
         if geom is None or geom.is_empty:
             geometry = {"type": "Point", "coordinates": [0, 0]}
             bbox = None
         else:
-            # Transform geometry from EPSG:2056 to WGS84 using the module-level transformer
-            # Drop Z coordinates — they are not needed and cause issues with single_sided buffers
-            wgs84_geom = shapely_transform(_TRANSFORMER.transform, force_2d(geom))
-            geometry = mapping(wgs84_geom)
-            bounds = wgs84_geom.bounds  # (minx, miny, maxx, maxy)
+            geometry = mapping(geom)
+            bounds = geom.bounds
             bbox = (bounds[0], bounds[1], bounds[2], bounds[3])
-
-        # Collect extra properties
-        skip_cols = {name_col, "geometry"}
-        if type_col:
-            skip_cols.add(type_col)
-        if id_col:
-            skip_cols.add(id_col)
 
         properties: dict[str, Any] = {
             "name": name,
             "type": normalized_type,
             "confidence": 1.0,
         }
-        for col in self._gdf.columns:
-            if col not in skip_cols:
-                val = row.get(col)
-                if val is not None and str(val) != "nan":
-                    properties[col] = val
+        for col in self._extra_cols:
+            val = row.get(col)
+            if val is not None and str(val) != "nan":
+                properties[col] = val
 
         return Feature(geometry=geometry, properties=properties, id=feature_id, bbox=bbox)
 
@@ -373,37 +382,23 @@ class SwissNames3DSource:
 
     def _fuzzy_search(self, normalized: str, threshold: float = 75.0) -> list[int]:
         """
-        Fuzzy search for names that partially match the search query.
+        Fuzzy search using a token inverted index for fast candidate pre-filtering.
 
-        Uses token matching to find results where at least one token from the
-        query matches a token in the indexed name. This handles cases like:
-        - "venoge" matching "la venoge"
-        - "rhone" matching "rhone valais"
-
-        Args:
-            normalized: The normalized search query.
-            threshold: Minimum fuzzy match score (0-100) to include a result.
-
-        Returns:
-            List of row indices for fuzzy-matched names, sorted by score (descending).
+        Looks up each query token in _token_index to find only the indexed names
+        that share at least one token, then scores those candidates with
+        token_set_ratio. Misses (no shared tokens) return instantly at O(1).
         """
+        candidates: set[str] = set()
+        for token in normalized.split():
+            candidates |= self._token_index.get(token, set())
+
         matches: list[tuple[int, float]] = []
-        query_tokens = set(normalized.split())
+        for name in candidates:
+            score = fuzz.token_set_ratio(normalized, name)
+            if score >= threshold:
+                for idx in self._name_index[name]:
+                    matches.append((idx, score))
 
-        for indexed_name, indices in self._name_index.items():
-            indexed_tokens = set(indexed_name.split())
-
-            # Check if any query token matches any indexed token
-            token_overlap = query_tokens & indexed_tokens
-
-            if token_overlap:
-                # Also use token_set_ratio for better matching of partial strings
-                score = fuzz.token_set_ratio(normalized, indexed_name)
-                if score >= threshold:
-                    for idx in indices:
-                        matches.append((idx, score))
-
-        # Sort by score (descending) to return best matches first
         matches.sort(key=lambda x: x[1], reverse=True)
         return [idx for idx, _ in matches]
 
@@ -420,9 +415,8 @@ class SwissNames3DSource:
         self._ensure_loaded()
         assert self._gdf is not None
 
-        id_col = self._detect_id_column()
-        if id_col:
-            matches = self._gdf[self._gdf[id_col].astype(str) == feature_id]
+        if self._id_col:
+            matches = self._gdf[self._gdf[self._id_col].astype(str) == feature_id]
             if not matches.empty:
                 return self._row_to_feature(matches.index[0])
 

--- a/etter/spatial.py
+++ b/etter/spatial.py
@@ -7,7 +7,8 @@ Shapely is used internally for geometry operations.
 """
 
 from pyproj import Geod, Transformer
-from shapely.geometry import MultiLineString, box, mapping, shape
+from shapely import clip_by_rect
+from shapely.geometry import MultiLineString, mapping, shape
 from shapely.geometry.base import BaseGeometry
 from shapely.geometry.linestring import LineString
 from shapely.geometry.polygon import Polygon
@@ -185,15 +186,13 @@ def _apply_clipping(geom: BaseGeometry, clip_direction: str) -> GeoJsonGeometry:
     midy = (miny + maxy) / 2
 
     if clip_direction == "north":
-        clip_box = box(minx, midy, maxx, maxy)
+        clipped = clip_by_rect(geom, minx, midy, maxx, maxy)
     elif clip_direction == "south":
-        clip_box = box(minx, miny, maxx, midy)
+        clipped = clip_by_rect(geom, minx, miny, maxx, midy)
     elif clip_direction == "east":
-        clip_box = box(midx, miny, maxx, maxy)
+        clipped = clip_by_rect(geom, midx, miny, maxx, maxy)
     else:  # west
-        clip_box = box(minx, miny, midx, maxy)
-
-    clipped = geom.intersection(clip_box)
+        clipped = clip_by_rect(geom, minx, miny, midx, maxy)
 
     if clipped.is_empty:
         return mapping(geom)  # Fallback — should never happen for a valid half-plane clip


### PR DESCRIPTION
## Summary

- **`etter/spatial.py`**: Replace `intersection(box())` with `shapely.clip_by_rect()` for directional half-plane clipping — dedicated fast path that skips the full GEOS overlay
- **`etter/datasources/swissnames3d.py`**: Cache column metadata once at load time (was re-detected on every `_row_to_feature()` call); add token inverted index for O(1) fuzzy candidate lookup; pre-apply `force_2d` + `to_crs` at load time; replace `gpd.pd.concat` with `pd.concat`
- **`etter/datasources/ign_bdcarto.py`**: Replace row-wise `apply(axis=1)` with vectorized `_assign_type_col()` — `fixed_type` layers use scalar broadcast, `type_map` layers use `.map()`, `commune_flags` uses column-wise boolean reduction; add token inverted index
- **`etter/datasources/composite.py`** + **`demo/main.py`**: Add `preload()` to each source and `CompositeDataSource`; call it in the FastAPI `lifespan` via `asyncio.to_thread` so file reads, reprojections, and index builds happen at startup instead of on the first user query

## Test plan

- [ ] `python -m pytest -v` passes
- [ ] `pre-commit run` passes on modified files
- [ ] First query in the demo is no longer slow after server startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)