### PR TITLE
fix(composite): align behavior with documented per-source max_results

### DIFF
--- a/etter/datasources/composite.py
+++ b/etter/datasources/composite.py
@@ -1,8 +1,7 @@
 """
 Composite data source that aggregates results from multiple GeoDataSource instances.
 
-Queries are forwarded to every registered source and results are merged,
-deduplicating by (name, type) while preserving original ordering.
+Queries are forwarded to every registered source and results are merged in order.
 """
 
 from typing import Protocol, runtime_checkable
@@ -70,10 +69,7 @@ class CompositeDataSource:
         merged: list[Feature] = []
 
         for source in self._sources:
-            for feature in source.search(name, type=type, max_results=max_results):
-                merged.append(feature)
-                if len(merged) >= max_results:
-                    return merged
+            merged.extend(source.search(name, type=type, max_results=max_results))
 
         return merged
 

--- a/tests/test_composite_datasource.py
+++ b/tests/test_composite_datasource.py
@@ -1,0 +1,174 @@
+"""
+Tests for CompositeDataSource.
+"""
+
+import pytest
+from geojson import Feature, Point
+
+from etter.datasources.composite import CompositeDataSource
+
+
+def make_feature(name: str, type: str, fid: str) -> Feature:
+    return Feature(
+        id=fid,
+        geometry=Point((6.0, 46.0)),
+        properties={"name": name, "type": type, "confidence": 1.0},
+    )
+
+
+class StubSource:
+    """Minimal GeoDataSource stub backed by a fixed list of features."""
+
+    def __init__(self, features: list[Feature], types: list[str] | None = None):
+        self._features = features
+        self._types = types or []
+
+    def search(self, _name: str, type: str | None = None, max_results: int = 10) -> list[Feature]:  # noqa: ARG002
+        return self._features[:max_results]
+
+    def get_by_id(self, feature_id: str) -> Feature | None:
+        return next((f for f in self._features if f["id"] == feature_id), None)
+
+    def get_available_types(self) -> list[str]:
+        return self._types
+
+
+class PreloadableStub(StubSource):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.preloaded = False
+
+    def preload(self) -> None:
+        self.preloaded = True
+
+
+# --- construction ---
+
+
+def test_requires_at_least_one_source():
+    with pytest.raises(ValueError):
+        CompositeDataSource()
+
+
+# --- search ---
+
+
+def test_search_merges_results_from_all_sources():
+    a = make_feature("Rhône", "river", "a1")
+    b = make_feature("Rhône", "river", "b1")
+    composite = CompositeDataSource(StubSource([a]), StubSource([b]))
+    results = composite.search("Rhône")
+    assert len(results) == 2
+    assert results[0]["id"] == "a1"
+    assert results[1]["id"] == "b1"
+
+
+def test_search_max_results_applied_per_source():
+    """Each source is capped independently; all sources are always queried."""
+    features_a = [make_feature("Rhône", "river", f"a{i}") for i in range(5)]
+    features_b = [make_feature("Rhône", "river", f"b{i}") for i in range(5)]
+    composite = CompositeDataSource(StubSource(features_a), StubSource(features_b))
+    results = composite.search("Rhône", max_results=3)
+    # source A returns 3, source B returns 3 → 6 total
+    assert len(results) == 6
+    assert results[0]["id"] == "a0"
+    assert results[3]["id"] == "b0"
+
+
+def test_search_second_source_queried_when_first_fills_quota():
+    """Regression for the short-circuit bug fixed in this codebase."""
+    features_a = [make_feature("Rhône", "river", f"a{i}") for i in range(10)]
+    b = make_feature("Rhône", "river", "b0")
+    composite = CompositeDataSource(StubSource(features_a), StubSource([b]))
+    results = composite.search("Rhône", max_results=10)
+    ids = [f["id"] for f in results]
+    assert "b0" in ids
+
+
+def test_search_empty_source_skipped():
+    b = make_feature("Geneva", "city", "b1")
+    composite = CompositeDataSource(StubSource([]), StubSource([b]))
+    results = composite.search("Geneva")
+    assert len(results) == 1
+    assert results[0]["id"] == "b1"
+
+
+def test_search_passes_type_and_name_to_sources():
+    received = {}
+
+    class CapturingSource:
+        def search(self, name, type=None, max_results=10):  # noqa: ARG002
+            received["name"] = name
+            received["type"] = type
+            return []
+
+        def get_by_id(self, _fid):
+            return None
+
+        def get_available_types(self):
+            return []
+
+    composite = CompositeDataSource(CapturingSource())
+    composite.search("Bern", type="city")
+    assert received == {"name": "Bern", "type": "city"}
+
+
+# --- get_by_id ---
+
+
+def test_get_by_id_returns_first_match():
+    a = make_feature("Lausanne", "city", "x1")
+    b = make_feature("Lausanne", "city", "x1")  # same id, second source
+    composite = CompositeDataSource(StubSource([a]), StubSource([b]))
+    result = composite.get_by_id("x1")
+    assert result is a
+
+
+def test_get_by_id_falls_through_to_second_source():
+    a = make_feature("Bern", "city", "a1")
+    b = make_feature("Zurich", "city", "b1")
+    composite = CompositeDataSource(StubSource([a]), StubSource([b]))
+    result = composite.get_by_id("b1")
+    assert result is b
+
+
+def test_get_by_id_returns_none_when_not_found():
+    composite = CompositeDataSource(StubSource([]))
+    assert composite.get_by_id("missing") is None
+
+
+# --- get_available_types ---
+
+
+def test_get_available_types_returns_union():
+    composite = CompositeDataSource(
+        StubSource([], types=["city", "lake"]),
+        StubSource([], types=["lake", "river"]),
+    )
+    assert composite.get_available_types() == ["city", "lake", "river"]
+
+
+def test_get_available_types_sorted():
+    composite = CompositeDataSource(
+        StubSource([], types=["river", "city"]),
+        StubSource([], types=["lake"]),
+    )
+    types = composite.get_available_types()
+    assert types == sorted(types)
+
+
+# --- preload ---
+
+
+def test_preload_calls_preloadable_sources():
+    p = PreloadableStub([])
+    s = StubSource([])
+    composite = CompositeDataSource(p, s)
+    composite.preload()
+    assert p.preloaded is True
+
+
+def test_preload_skips_non_preloadable_sources():
+    s = StubSource([])
+    composite = CompositeDataSource(s)
+    composite.preload()  # must not raise


### PR DESCRIPTION
No tests existed for CompositeDataSource (the only datasource without coverage). The short-circuit `if len(merged) >= max_results: return` was left over from the dedup removal in 6860f24: it capped the *total* instead of per source, so source 2 was never queried once source 1 filled the quota (issue #33).

Drop the short-circuit so max_results is applied independently by each source. Also remove the stale "deduplicating by (name, type)" mention from the module docstring.

Tests cover: search merge across sources, per-source max_results cap, regression for the short-circuit, get_by_id first-wins and fall-through, get_available_types union and sort, preload dispatch.