### PR TITLE
refactor(datasources): extract shared fuzzy_search_index helper

### DIFF
--- a/etter/datasources/ign_bdcarto.py
+++ b/etter/datasources/ign_bdcarto.py
@@ -34,10 +34,9 @@ from typing import Any, cast
 import geopandas as gpd
 import pandas as pd
 from geojson import Feature
-from rapidfuzz import fuzz
 from shapely.geometry import mapping
 
-from .location_types import TypeMap, get_matching_types, merge_segments
+from .location_types import TypeMap, fuzzy_search_index, get_matching_types, merge_segments
 
 logger = logging.getLogger(__name__)
 
@@ -460,20 +459,7 @@ class IGNBDCartoSource:
         return features[:max_results]
 
     def _fuzzy_search(self, normalized: str, threshold: float = 75.0) -> list[int]:
-        """Fuzzy search using a token inverted index for fast candidate pre-filtering."""
-        candidates: set[str] = set()
-        for token in normalized.split():
-            candidates |= self._token_index.get(token, set())
-
-        matches: list[tuple[int, float]] = []
-        for name in candidates:
-            score = fuzz.token_set_ratio(normalized, name)
-            if score >= threshold:
-                for idx in self._name_index[name]:
-                    matches.append((idx, score))
-
-        matches.sort(key=lambda x: x[1], reverse=True)
-        return [idx for idx, _ in matches]
+        return fuzzy_search_index(normalized, self._token_index, self._name_index, threshold)
 
     def get_by_id(self, feature_id: str) -> Feature | None:
         """

--- a/etter/datasources/location_types.py
+++ b/etter/datasources/location_types.py
@@ -16,6 +16,7 @@ from collections import defaultdict
 from typing import Literal
 
 from geojson import Feature
+from rapidfuzz import fuzz
 from shapely.geometry import mapping, shape
 from shapely.ops import unary_union
 
@@ -386,3 +387,40 @@ def merge_segments(features: list[Feature]) -> list[Feature]:
                 )
             )
     return merged
+
+
+def fuzzy_search_index(
+    normalized: str,
+    token_index: dict[str, set[str]],
+    name_index: dict[str, list[int]],
+    threshold: float = 75.0,
+) -> list[int]:
+    """
+    Fuzzy search over a token-inverted index.
+
+    Uses token_sort_ratio so that single-token candidates do not score 100%
+    against multi-token queries (avoids the subset-match inflation of
+    token_set_ratio).
+
+    Args:
+        normalized: Already-normalized query string.
+        token_index: Maps each token to the set of indexed name keys that contain it.
+        name_index: Maps each indexed name key to its list of row indices.
+        threshold: Minimum score (0–100) to include a candidate.
+
+    Returns:
+        Row indices sorted by descending score.
+    """
+    candidates: set[str] = set()
+    for token in normalized.split():
+        candidates |= token_index.get(token, set())
+
+    matches: list[tuple[int, float]] = []
+    for name in candidates:
+        score = fuzz.token_sort_ratio(normalized, name)
+        if score >= threshold:
+            for idx in name_index[name]:
+                matches.append((idx, score))
+
+    matches.sort(key=lambda x: x[1], reverse=True)
+    return [idx for idx, _ in matches]

--- a/etter/datasources/swissnames3d.py
+++ b/etter/datasources/swissnames3d.py
@@ -14,11 +14,10 @@ from typing import Any
 import geopandas as gpd
 import pandas as pd
 from geojson import Feature
-from rapidfuzz import fuzz
 from shapely import force_2d
 from shapely.geometry import mapping
 
-from .location_types import TypeMap, get_matching_types
+from .location_types import TypeMap, fuzzy_search_index, get_matching_types
 
 # Map normalized, grouped types to their OBJEKTART values.
 # Each type groups related OBJEKTART values (e.g., lake groups: See, Seeteil).
@@ -381,26 +380,7 @@ class SwissNames3DSource:
         return features[:max_results]
 
     def _fuzzy_search(self, normalized: str, threshold: float = 75.0) -> list[int]:
-        """
-        Fuzzy search using a token inverted index for fast candidate pre-filtering.
-
-        Looks up each query token in _token_index to find only the indexed names
-        that share at least one token, then scores those candidates with
-        token_set_ratio. Misses (no shared tokens) return instantly at O(1).
-        """
-        candidates: set[str] = set()
-        for token in normalized.split():
-            candidates |= self._token_index.get(token, set())
-
-        matches: list[tuple[int, float]] = []
-        for name in candidates:
-            score = fuzz.token_set_ratio(normalized, name)
-            if score >= threshold:
-                for idx in self._name_index[name]:
-                    matches.append((idx, score))
-
-        matches.sort(key=lambda x: x[1], reverse=True)
-        return [idx for idx, _ in matches]
+        return fuzzy_search_index(normalized, self._token_index, self._name_index, threshold)
 
     def get_by_id(self, feature_id: str) -> Feature | None:
         """


### PR DESCRIPTION
token_set_ratio treats any single-token candidate as a 100% match against a multi-token query (subset semantics), flooding results with false positives — e.g. 'lac Morat' returned 1843 French 'le Lac' features. Switch to token_sort_ratio, which penalises length mismatches.

Both SwissNames3DSource and IGNBDCartoSource had identical _fuzzy_search implementations; extract to fuzzy_search_index() in location_types.