### PR TITLE
ci: cache downloaded datasets in test-demo workflow

### DIFF
--- a/.github/workflows/test-demo.yml
+++ b/.github/workflows/test-demo.yml
@@ -43,7 +43,14 @@ jobs:
       - name: Set up env
         run: |
           cp demo/.env.example demo/.env
+      - name: Cache data
+        id: cache-data
+        uses: actions/cache@v5
+        with:
+          path: data/
+          key: data-swissnames3d-2025-bdcarto-2025-09-15
       - name: Download data
+        if: steps.cache-data.outputs.cache-hit != 'true'
         run: |
           make download-data
           make download-data-ign


### PR DESCRIPTION
Avoids re-downloading SwissNames3D and BD-CARTO on every run. Cache key encodes the dataset versions from the Makefile URLs.