### PR TITLE
fix: merge segments and serialize GeoDataFrame values correctly

### DIFF
--- a/etter/datasources/ign_bdcarto.py
+++ b/etter/datasources/ign_bdcarto.py
@@ -36,7 +36,7 @@ import pandas as pd
 from geojson import Feature
 from shapely.geometry import mapping
 
-from .location_types import TypeMap, fuzzy_search_index, get_matching_types, merge_segments
+from .location_types import TypeMap, fuzzy_search_index, get_matching_types, merge_segments, to_serializable
 
 logger = logging.getLogger(__name__)
 
@@ -219,27 +219,6 @@ def _index_keys(name: str) -> list[str]:
     return keys
 
 
-def _to_json_value(val: Any) -> str | float | int | bool | None:
-    """
-    Convert a pandas/numpy value to a JSON-serializable Python primitive.
-
-    Returns ``None`` for missing values (NaN, NaT, None) so they are omitted
-    from the feature properties.
-    """
-    if val is None:
-        return None
-    try:
-        if pd.isna(val):
-            return None
-    except (TypeError, ValueError):
-        pass
-    if isinstance(val, pd.Timestamp):
-        return val.isoformat()
-    if hasattr(val, "item"):
-        return val.item()
-    return val
-
-
 def _assign_type_col(gdf: gpd.GeoDataFrame, cfg: dict[str, Any]) -> None:
     """Assign the _TYPE_COL column using vectorized operations."""
     if cfg.get("commune_flags"):
@@ -407,7 +386,7 @@ class IGNBDCartoSource:
         }
         for col in self._gdf.columns:
             if col not in skip_cols:
-                val = _to_json_value(row.get(col))
+                val = to_serializable(row.get(col))
                 if val is not None:
                     properties[col] = val
 

--- a/etter/datasources/location_types.py
+++ b/etter/datasources/location_types.py
@@ -13,8 +13,9 @@ of type "lake", "river", "pond", etc.
 from __future__ import annotations
 
 from collections import defaultdict
-from typing import Literal
+from typing import Any, Literal
 
+import pandas as pd
 from geojson import Feature
 from rapidfuzz import fuzz
 from shapely.geometry import mapping, shape
@@ -315,6 +316,26 @@ def get_matching_types(type_hint: str) -> list[str]:
 
     # Unknown type - return empty (no match)
     return []
+
+
+def to_serializable(val: Any) -> str | int | float | bool | None:
+    """Convert a pandas/numpy value to a JSON-serializable Python primitive.
+
+    Returns None for missing values (NaN, NaT, None) so callers can omit them
+    from feature properties.
+    """
+    if val is None:
+        return None
+    try:
+        if pd.isna(val):
+            return None
+    except (TypeError, ValueError):
+        pass
+    if hasattr(val, "isoformat"):
+        return val.isoformat()
+    if hasattr(val, "item"):
+        return val.item()
+    return val
 
 
 # Segment merging

--- a/etter/datasources/swissboundaries3d.py
+++ b/etter/datasources/swissboundaries3d.py
@@ -17,7 +17,7 @@ from geojson import Feature
 from shapely import force_2d
 from shapely.geometry import mapping
 
-from .location_types import TypeMap, fuzzy_search_index, get_matching_types
+from .location_types import TypeMap, fuzzy_search_index, get_matching_types, to_serializable
 
 # Map normalized, grouped types to their OBJEKTART values.
 # Each type groups related OBJEKTART values (e.g., lake groups: See, Seeteil).
@@ -242,8 +242,8 @@ class SwissBoundaries3DSource:
             "confidence": 1.0,
         }
         for col in self._extra_cols:
-            val = row.get(col)
-            if val is not None and str(val) != "nan":
+            val = to_serializable(row.get(col))
+            if val is not None:
                 properties[col] = val
 
         return Feature(geometry=geometry, properties=properties, id=feature_id, bbox=bbox)

--- a/etter/datasources/swissnames3d.py
+++ b/etter/datasources/swissnames3d.py
@@ -17,7 +17,7 @@ from geojson import Feature
 from shapely import force_2d
 from shapely.geometry import mapping
 
-from .location_types import TypeMap, fuzzy_search_index, get_matching_types
+from .location_types import TypeMap, fuzzy_search_index, get_matching_types, merge_segments, to_serializable
 
 # Map normalized, grouped types to their OBJEKTART values.
 # Each type groups related OBJEKTART values (e.g., lake groups: See, Seeteil).
@@ -326,8 +326,8 @@ class SwissNames3DSource:
             "confidence": 1.0,
         }
         for col in self._extra_cols:
-            val = row.get(col)
-            if val is not None and str(val) != "nan":
+            val = to_serializable(row.get(col))
+            if val is not None:
                 properties[col] = val
 
         return Feature(geometry=geometry, properties=properties, id=feature_id, bbox=bbox)
@@ -377,6 +377,7 @@ class SwissNames3DSource:
                 # Unknown type hint, fall back to exact string match
                 features = [f for f in features if f["properties"].get("type") == type.lower()]
 
+        features = merge_segments(features)
         return features[:max_results]
 
     def _fuzzy_search(self, normalized: str, threshold: float = 75.0) -> list[int]:


### PR DESCRIPTION
- Call merge_segments in SwissNames3DSource.search so linear features like rivers (e.g. La Venoge) are returned as a single geometry instead of separate segments
- Add to_serializable in location_types to convert numpy scalars and pandas Timestamps to JSON-native types; replaces the local _to_json_value in IGNBDCartoSource and is now used consistently across all three file-based datasources