### PR TITLE
feat: add Python 3.14 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - uses: actions/checkout@v7

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,13 +17,14 @@ classifiers     = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
     "Topic :: Scientific/Engineering :: GIS",
 ]
 dependencies = [
     "langchain>=1.2",
     "pydantic>=2.12",
-    "shapely>=2.1",
+    "shapely>=2.1.2",
     "pyproj>=3.7",
     "geopandas>=1.1",
     "rapidfuzz>=3.14",

--- a/uv.lock
+++ b/uv.lock
@@ -513,7 +513,7 @@ requires-dist = [
     { name = "rapidfuzz", specifier = ">=3.14" },
     { name = "rich", marker = "extra == 'dev'", specifier = ">=15.0.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.15" },
-    { name = "shapely", specifier = ">=2.1" },
+    { name = "shapely", specifier = ">=2.1.2" },
     { name = "sqlalchemy", marker = "extra == 'postgis'", specifier = ">=2.0" },
     { name = "testcontainers", extras = ["postgres"], marker = "extra == 'dev'", specifier = ">=4.14.2" },
     { name = "trio", marker = "extra == 'dev'", specifier = ">=0.28" },


### PR DESCRIPTION
Add Python 3.14 to the CI test matrix and PyPI classifiers. Bump shapely minimum to 2.1.2, the first release with cp314 wheels.