### PR TITLE
chore: load real datasource fixtures once per module

### DIFF
--- a/tests/test_ign_bdcarto.py
+++ b/tests/test_ign_bdcarto.py
@@ -18,9 +18,9 @@ def source():
     return IGNBDCartoSource(FIXTURE_PATH)
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def real_source():
-    """IGNBDCartoSource loaded from real BD-CARTO GeoPackage files."""
+    """IGNBDCartoSource loaded from real BD-CARTO GeoPackage files (loaded once per module — tests must not mutate it)."""
     if not DATA_DIR.exists():
         pytest.skip("Real BD-CARTO data directory not found")
     return IGNBDCartoSource(DATA_DIR)

--- a/tests/test_swissboundaries3d.py
+++ b/tests/test_swissboundaries3d.py
@@ -21,9 +21,9 @@ def source():
     return SwissBoundaries3DSource(FIXTURE_PATH)
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def real_source():
-    """Create a SwissBoundaries3DSource instance using real shapefiles."""
+    """Create a SwissBoundaries3DSource instance using real shapefiles (loaded once per module — tests must not mutate it)."""
     if not DATA_DIR.exists():
         pytest.skip("Real SwissBoundaries3D data directory not found")
     # Check for at least one of the expected shapefiles

--- a/tests/test_swissnames3d.py
+++ b/tests/test_swissnames3d.py
@@ -21,9 +21,9 @@ def source():
     return SwissNames3DSource(FIXTURE_PATH)
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def real_source():
-    """Create a SwissNames3DSource instance using real shapefiles."""
+    """Create a SwissNames3DSource instance using real shapefiles (loaded once per module — tests must not mutate it)."""
     if not DATA_DIR.exists():
         pytest.skip("Real SwissNames3D data directory not found")
     return SwissNames3DSource(DATA_DIR)


### PR DESCRIPTION
The real_source fixtures were function-scoped, so the 10 swissnames3d tests using real shapefiles each reloaded the full dataset (18-33s per test). All consumers are read-only, so scope the fixtures to the module: the data loads once and the full suite time drops by ~60%.