### PR TITLE
fix: correct word_similarity argument order in PostGIS fuzzy search

### DIFF
--- a/etter/datasources/postgis.py
+++ b/etter/datasources/postgis.py
@@ -125,6 +125,13 @@ class PostGISDataSource:
         fuzzy_threshold: Minimum ``pg_trgm`` similarity score (0-1) used for
             fuzzy fallback search when no exact ``ILIKE`` match is found.
 
+    .. note::
+        The fuzzy fallback scans every row (``word_similarity()`` is not
+        indexable via a plain B-tree). For large tables, add a trigram index
+        on the name column to speed it up::
+
+            CREATE INDEX ON <table> USING gist (name gist_trgm_ops);
+
     Example: unmodified SwissNames3D table::
 
         from sqlalchemy import create_engine
@@ -349,11 +356,11 @@ class PostGISDataSource:
         name_expr = f"lower({self._name_col})"
         if self._check_unaccent(conn):
             name_expr = f"unaccent({name_expr})"
-        sql = sa.text(
-            f"SELECT {cols} FROM {self._table} "  # noqa: S608
-            f"WHERE {name_expr} = :query{type_clause} "
-            f"LIMIT :limit"
-        )
+        sql = sa.text(f"""
+            SELECT {cols} FROM {self._table}
+            WHERE {name_expr} = :query{type_clause}
+            LIMIT :limit
+        """)  # noqa: S608
         params: dict[str, Any] = {
             "query": _normalize_name(name),
             "limit": fetch_limit,
@@ -390,11 +397,11 @@ class PostGISDataSource:
         else:
             name_expr = self._name_col
             pattern = f"%{name}%"
-        sql = sa.text(
-            f"SELECT {cols} FROM {self._table} "  # noqa: S608
-            f"WHERE {name_expr} ILIKE :pattern{type_clause} "
-            f"LIMIT :limit"
-        )
+        sql = sa.text(f"""
+            SELECT {cols} FROM {self._table}
+            WHERE {name_expr} ILIKE :pattern{type_clause}
+            LIMIT :limit
+        """)  # noqa: S608
         params: dict[str, Any] = {"pattern": pattern, "limit": fetch_limit, **type_params}
         try:
             result = conn.execute(sql, params)
@@ -428,12 +435,18 @@ class PostGISDataSource:
             )
             name_expr = f"lower({self._name_col})"
         type_clause, type_params = self._type_filter_sql(type_filter)
-        sql = sa.text(
-            f"SELECT {cols} FROM {self._table} "  # noqa: S608
-            f"WHERE word_similarity({name_expr}, :query) > :threshold{type_clause} "
-            f"ORDER BY word_similarity({name_expr}, :query) DESC "
-            f"LIMIT :limit"
-        )
+        # Compute word_similarity() once in the subquery and reuse it via the
+        # "sim" alias, rather than evaluating it separately for the WHERE
+        # filter and the ORDER BY sort.
+        sql = sa.text(f"""
+            SELECT id, name, type, geojson FROM (
+                SELECT {cols}, word_similarity(:query, {name_expr}) AS sim
+                FROM {self._table} WHERE TRUE{type_clause}
+            ) AS scored
+            WHERE sim > :threshold
+            ORDER BY sim DESC
+            LIMIT :limit
+        """)  # noqa: S608
         params: dict[str, Any] = {
             "query": normalized_query,
             "threshold": self._fuzzy_threshold,

--- a/tests/test_postgis_datasource.py
+++ b/tests/test_postgis_datasource.py
@@ -62,9 +62,10 @@ def db_engine(postgis_container):
     url = postgis_container.get_connection_url()
     engine = create_engine(url)
 
-    # Enable PostGIS extension
+    # Enable PostGIS and pg_trgm extensions
     with engine.connect() as conn:
         conn.execute(text("CREATE EXTENSION IF NOT EXISTS postgis"))
+        conn.execute(text("CREATE EXTENSION IF NOT EXISTS pg_trgm"))
         conn.commit()
 
     yield engine
@@ -146,6 +147,32 @@ def source(db_engine, populated_table):  # noqa: ARG001
         geometry_column="geom",
         id_column="id",
     )
+
+
+@pytest.fixture(scope="module")
+def fuzzy_source(db_engine, populated_table):  # noqa: ARG001
+    """Same table, but with a low fuzzy threshold to make fuzzy-only matches robust to test."""
+    return PostGISDataSource(
+        connection=db_engine,
+        table=TABLE_NAME,
+        name_column="name",
+        type_column="type",
+        geometry_column="geom",
+        id_column="id",
+        fuzzy_threshold=0.5,
+    )
+
+
+def test_search_fuzzy_typo_multiword_name(fuzzy_source):
+    """A typo'd query that isn't a substring of the name still matches via pg_trgm fuzzy search.
+
+    Regression test for word_similarity(a, b) argument order: it is not
+    symmetric, and treating the (short) query as the "word" searched for
+    within the (potentially multi-word) name is required for this to match.
+    """
+    results = fuzzy_source.search("Venoje")  # typo of "Venoge", not a substring of "La Venoge"
+    assert len(results) >= 1
+    assert any("Venoge" in r["properties"]["name"] for r in results)
 
 
 def test_search_exact(source):


### PR DESCRIPTION
pg_trgm's word_similarity(a, b) is asymmetric: a is treated as the word searched for within b. The fuzzy fallback had this backwards (name, query), which crippled matches for short/partial queries against multi-word names. Also dedupe the repeated word_similarity() call into a single subquery, and document that a gist_trgm_ops index is recommended for large tables.