### PR TITLE
perf: filter by type before building Features in search()

### DIFF
--- a/etter/datasources/ign_bdcarto.py
+++ b/etter/datasources/ign_bdcarto.py
@@ -360,13 +360,19 @@ class IGNBDCartoSource:
                         self._token_index[token] = set()
                     self._token_index[token].add(key)
 
+    def _row_type(self, idx: int) -> str:
+        """Return a row's normalized type without building its full Feature (geometry, etc.)."""
+        assert self._gdf is not None
+        row = self._gdf.iloc[idx]
+        return str(row[_TYPE_COL]) if pd.notna(row.get(_TYPE_COL)) else "unknown"
+
     def _row_to_feature(self, idx: int) -> Feature:
         """Convert a GeoDataFrame row to a GeoJSON Feature dict (WGS84)."""
         assert self._gdf is not None
         row = self._gdf.iloc[idx]
 
         name = str(row[_NAME_COL])
-        normalized_type = str(row[_TYPE_COL]) if pd.notna(row.get(_TYPE_COL)) else "unknown"
+        normalized_type = self._row_type(idx)
         feature_id = str(row["cleabs"]) if pd.notna(row.get("cleabs")) else str(idx)
 
         geom = row.geometry
@@ -423,15 +429,17 @@ class IGNBDCartoSource:
         if not indices:
             indices = self._fuzzy_search(normalized)
 
-        features = [self._row_to_feature(idx) for idx in indices]
-
+        # Filter by type if type hint provided, before building the (geometry-heavy) Feature
+        # for each row — so rows dropped by the filter skip that work entirely.
         if type is not None:
             matching_types = get_matching_types(type)
             logger.debug("Filtering results by type hint %r → matching types: %s", type, matching_types)
             if matching_types:
-                features = [f for f in features if f["properties"].get("type") in matching_types]
+                indices = [idx for idx in indices if self._row_type(idx) in matching_types]
             else:
-                features = [f for f in features if f["properties"].get("type") == type.lower()]
+                indices = [idx for idx in indices if self._row_type(idx) == type.lower()]
+
+        features = [self._row_to_feature(idx) for idx in indices]
 
         features = merge_segments(features)
 

--- a/etter/datasources/swissnames3d.py
+++ b/etter/datasources/swissnames3d.py
@@ -298,15 +298,20 @@ class SwissNames3DSource:
                     return col
         return None
 
+    def _row_type(self, idx: int) -> str:
+        """Return a row's normalized type without building its full Feature (geometry, etc.)."""
+        assert self._gdf is not None
+        row = self._gdf.iloc[idx]
+        raw_type = str(row[self._type_col]) if self._type_col and row.get(self._type_col) else "unknown"
+        return _objektart_to_type(raw_type)
+
     def _row_to_feature(self, idx: int) -> Feature:
         """Convert a GeoDataFrame row to a GeoJSON Feature dict with WGS84 geometry."""
         assert self._gdf is not None
         row = self._gdf.iloc[idx]
 
         name = str(row[self._name_col])
-
-        raw_type = str(row[self._type_col]) if self._type_col and row.get(self._type_col) else "unknown"
-        normalized_type = _objektart_to_type(raw_type)
+        normalized_type = self._row_type(idx)
 
         feature_id = str(row[self._id_col]) if self._id_col and row.get(self._id_col) else str(idx)
 
@@ -364,18 +369,19 @@ class SwissNames3DSource:
         if not indices:
             indices = self._fuzzy_search(normalized)
 
-        features = [self._row_to_feature(idx) for idx in indices]
-
-        # Filter by type if type hint provided.
+        # Filter by type if type hint provided, before building the (geometry-heavy) Feature
+        # for each row — so rows dropped by the filter skip that work entirely.
         # Expand via the type hierarchy so that category hints (e.g. "water") match
         # all concrete types within that category ("lake", "river", "pond", ...).
         if type is not None:
             matching_types = get_matching_types(type)
             if matching_types:
-                features = [f for f in features if f["properties"].get("type") in matching_types]
+                indices = [idx for idx in indices if self._row_type(idx) in matching_types]
             else:
                 # Unknown type hint, fall back to exact string match
-                features = [f for f in features if f["properties"].get("type") == type.lower()]
+                indices = [idx for idx in indices if self._row_type(idx) == type.lower()]
+
+        features = [self._row_to_feature(idx) for idx in indices]
 
         features = merge_segments(features)
         return features[:max_results]

--- a/tests/fixtures/swissnames3d_sample.json
+++ b/tests/fixtures/swissnames3d_sample.json
@@ -78,6 +78,21 @@
     {
       "type": "Feature",
       "properties": {
+        "UUID": "uuid-rhone-2",
+        "NAME": "Rhône",
+        "OBJEKTART": "Fliessgewaesser"
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [2300000.0, 1080000.0],
+          [2200000.0, 1070000.0]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
         "UUID": "uuid-zurich",
         "NAME": "Zürich",
         "OBJEKTART": "Ort",

--- a/tests/test_swissnames3d.py
+++ b/tests/test_swissnames3d.py
@@ -33,7 +33,7 @@ def test_load_data(source):
     """Test that data loads and columns are detected."""
     source._ensure_loaded()
     assert source._gdf is not None
-    assert len(source._gdf) == 5  # 5 features in fixture
+    assert len(source._gdf) == 6  # 6 features in fixture
 
 
 def test_search_exact(source):
@@ -136,6 +136,17 @@ def test_search_type_exact_still_works(source):
     # A mismatched concrete type returns nothing
     results_none = source.search("Lac Léman", type="river")
     assert len(results_none) == 0
+
+
+def test_search_type_filter_merges_before_truncating(source):
+    """The type filter is applied to row indices before building Features (perf optimization),
+    but merging disconnected segments of the same type must still see the full filtered set —
+    not have segments silently dropped by max_results before they can be merged."""
+    results = source.search("Rhône", type="river", max_results=1)
+    assert len(results) == 1
+    # Both fixture segments (uuid-rhone, uuid-rhone-2) must be merged into this one result,
+    # not just the first segment found.
+    assert "MultiLineString" in results[0]["geometry"]["type"] or results[0]["geometry"]["type"] == "GeometryCollection"
 
 
 # Tests for real SwissNames3D shapefiles


### PR DESCRIPTION
## Summary
- `SwissNames3DSource.search()` and `IGNBDCartoSource.search()` both built a full `Feature` (geometry conversion via `shapely.mapping`, bounds computation, etc.) for every name-matched row, then filtered by type afterward. For a common/ambiguous name with many matches, that does expensive per-row work for rows the type filter then discards.
- Both now filter row indices by type first (a cheap type-column lookup via a new `_row_type()` helper) and only build `Feature`s for the survivors.
- `merge_segments`/`max_results` ordering is unchanged in both — multi-segment features (e.g. rivers split into several rows) are still merged from the full type-filtered set before truncation, not before.

## Test plan
- [x] `SwissNames3DSource`: added a second `Rhône` fixture segment + `test_search_type_filter_merges_before_truncating`, proving the reorder still merges both segments correctly under `max_results=1`.
- [x] `IGNBDCartoSource`: relies on the existing real-data `test_real_search_river_merged` (Oise segments), which exercises the same type-filter + merge interaction.
- [x] Full suite: `uv run pytest tests/test_swissnames3d.py tests/test_ign_bdcarto.py` — 47 passed, only the pre-existing unrelated `test_multiple_disconnected_segments` failure (confirmed identical before/after via `git stash`).
- [x] `pre-commit` (ruff check/format, ty) clean on both changed files.