### PR TITLE
fix: consolidate duplicated datasource helper code

### DIFF
--- a/etter/datasources/geo_dataframe_source.py
+++ b/etter/datasources/geo_dataframe_source.py
@@ -1,0 +1,73 @@
+"""Shared base for lazily-loaded, in-memory GeoDataFrame-backed geo datasources."""
+
+from typing import TYPE_CHECKING
+
+from geojson import Feature
+
+from .location_types import fuzzy_search_index
+
+if TYPE_CHECKING:
+    import geopandas as gpd
+
+
+class GeoDataFrameSource:
+    """
+    Shared lazy-loading, fuzzy-search, and by-id lookup behavior for datasources backed by
+    an in-memory GeoDataFrame with a name/token index (SwissNames3DSource, IGNBDCartoSource,
+    SwissBoundaries3DSource).
+
+    Subclasses set ``self._gdf``, ``self._name_index``, ``self._token_index``, and
+    ``self._id_col`` in ``__init__``, and implement ``_load_data()`` and ``_row_to_feature()``.
+    """
+
+    _gdf: "gpd.GeoDataFrame | None"
+    _name_index: dict[str, list[int]]
+    _token_index: dict[str, set[str]]
+    _id_col: str | None
+
+    def preload(self) -> None:
+        """Eagerly load data. Call at startup to avoid first-query latency."""
+        self._ensure_loaded()
+
+    def _ensure_loaded(self) -> None:
+        """Load data lazily on first access."""
+        if self._gdf is not None:
+            return
+        self._load_data()
+
+    def _load_data(self) -> None:
+        raise NotImplementedError
+
+    def _row_to_feature(self, idx: int) -> Feature:
+        raise NotImplementedError
+
+    def _fuzzy_search(self, normalized: str, threshold: float = 75.0) -> list[int]:
+        return fuzzy_search_index(normalized, self._token_index, self._name_index, threshold)
+
+    def get_by_id(self, feature_id: str) -> Feature | None:
+        """
+        Get a specific feature by its unique identifier.
+
+        Args:
+            feature_id: Unique identifier (e.g. a UUID, ``cleabs`` string, or row index).
+
+        Returns:
+            The matching GeoJSON Feature dict, or None if not found.
+        """
+        self._ensure_loaded()
+        assert self._gdf is not None
+
+        if self._id_col:
+            matches = self._gdf[self._gdf[self._id_col].astype(str) == feature_id]
+            if not matches.empty:
+                return self._row_to_feature(matches.index[0])
+
+        # Fallback: try as row index
+        try:
+            idx = int(feature_id)
+            if 0 <= idx < len(self._gdf):
+                return self._row_to_feature(idx)
+        except ValueError:
+            pass
+
+        return None

--- a/etter/datasources/ign_bdcarto.py
+++ b/etter/datasources/ign_bdcarto.py
@@ -27,7 +27,6 @@ Expected data layout (produced by scripts/extract_bdcarto.sh):
 """
 
 import logging
-import unicodedata
 from pathlib import Path
 from typing import Any, cast
 
@@ -36,7 +35,9 @@ import pandas as pd
 from geojson import Feature
 from shapely.geometry import mapping
 
-from .location_types import TypeMap, fuzzy_search_index, get_matching_types, merge_segments, to_serializable
+from .geo_dataframe_source import GeoDataFrameSource
+from .location_types import TypeMap, get_matching_types, merge_segments, to_serializable
+from .text import normalize_name
 
 logger = logging.getLogger(__name__)
 
@@ -191,12 +192,6 @@ def _build_type_map() -> TypeMap:
 IGN_BDCARTO_TYPE_MAP: TypeMap = _build_type_map()
 
 
-def _normalize_name(name: str) -> str:
-    """Lowercase, strip diacritics for accent-insensitive matching."""
-    nfkd = unicodedata.normalize("NFKD", name)
-    return "".join(c for c in nfkd if not unicodedata.combining(c)).lower().strip()
-
-
 _FR_ARTICLES = ("le ", "la ", "les ", "l'", "l'", "de ", "du ", "des ")
 
 
@@ -208,7 +203,7 @@ def _index_keys(name: str) -> list[str]:
     leading French article stripped, so that searching for "Rhône" finds
     features stored as "le Rhône".
     """
-    full = _normalize_name(name)
+    full = normalize_name(name)
     keys = [full]
     for article in _FR_ARTICLES:
         if full.startswith(article):
@@ -239,7 +234,7 @@ def _assign_type_col(gdf: gpd.GeoDataFrame, cfg: dict[str, Any]) -> None:
         gdf[_TYPE_COL] = "unknown"
 
 
-class IGNBDCartoSource:
+class IGNBDCartoSource(GeoDataFrameSource):
     """
     Geographic data source backed by IGN's BD-CARTO 5.0 dataset.
 
@@ -269,15 +264,7 @@ class IGNBDCartoSource:
         self._gdf: gpd.GeoDataFrame | None = None
         self._name_index: dict[str, list[int]] = {}
         self._token_index: dict[str, set[str]] = {}
-
-    def preload(self) -> None:
-        """Eagerly load data. Call at startup to avoid first-query latency."""
-        self._ensure_loaded()
-
-    def _ensure_loaded(self) -> None:
-        if self._gdf is not None:
-            return
-        self._load_data()
+        self._id_col: str | None = "cleabs"
 
     def _load_data(self) -> None:
         if self._data_path.is_dir():
@@ -423,7 +410,7 @@ class IGNBDCartoSource:
         """
         self._ensure_loaded()
 
-        normalized = _normalize_name(name)
+        normalized = normalize_name(name)
         indices = self._name_index.get(normalized, [])
 
         if not indices:
@@ -444,36 +431,6 @@ class IGNBDCartoSource:
         features = merge_segments(features)
 
         return features[:max_results]
-
-    def _fuzzy_search(self, normalized: str, threshold: float = 75.0) -> list[int]:
-        return fuzzy_search_index(normalized, self._token_index, self._name_index, threshold)
-
-    def get_by_id(self, feature_id: str) -> Feature | None:
-        """
-        Get a feature by its ``cleabs`` identifier or row index.
-
-        Args:
-            feature_id: ``cleabs`` string or integer row index.
-
-        Returns:
-            Matching GeoJSON Feature dict, or ``None``.
-        """
-        self._ensure_loaded()
-        assert self._gdf is not None
-
-        if "cleabs" in self._gdf.columns:
-            matches = self._gdf[self._gdf["cleabs"].astype(str) == feature_id]
-            if not matches.empty:
-                return self._row_to_feature(matches.index[0])
-
-        try:
-            idx = int(feature_id)
-            if 0 <= idx < len(self._gdf):
-                return self._row_to_feature(idx)
-        except ValueError:
-            pass
-
-        return None
 
     def get_available_types(self) -> list[str]:
         """

--- a/etter/datasources/postgis.py
+++ b/etter/datasources/postgis.py
@@ -26,12 +26,12 @@ from __future__ import annotations
 
 import json
 import logging
-import unicodedata
 from typing import TYPE_CHECKING, Any
 
 from geojson import Feature
 
 from .location_types import TypeMap, get_matching_types, merge_segments
+from .text import normalize_name
 
 logger = logging.getLogger(__name__)
 
@@ -42,13 +42,6 @@ if TYPE_CHECKING:
 
     from sqlalchemy import Engine
     from sqlalchemy.engine import Connection, Row
-
-
-def _normalize_name(name: str) -> str:
-    """Normalize a name for accent- and case-insensitive matching."""
-    nfkd = unicodedata.normalize("NFKD", name)
-    stripped = "".join(c for c in nfkd if not unicodedata.combining(c))
-    return stripped.lower().strip()
 
 
 def _require_sqlalchemy() -> types.ModuleType:
@@ -362,7 +355,7 @@ class PostGISDataSource:
             LIMIT :limit
         """)  # noqa: S608
         params: dict[str, Any] = {
-            "query": _normalize_name(name),
+            "query": normalize_name(name),
             "limit": fetch_limit,
             **type_params,
         }
@@ -390,7 +383,7 @@ class PostGISDataSource:
         only).
         """
         type_clause, type_params = self._type_filter_sql(type_filter)
-        normalized = _normalize_name(name)
+        normalized = normalize_name(name)
         if self._check_unaccent(conn):
             name_expr = f"unaccent(lower({self._name_col}))"
             pattern = f"%{normalized}%"
@@ -425,7 +418,7 @@ class PostGISDataSource:
                 "pg_trgm extension not available. Fuzzy search disabled. Install it with: CREATE EXTENSION pg_trgm;"
             )
             return []
-        normalized_query = _normalize_name(name)
+        normalized_query = normalize_name(name)
         if self._check_unaccent(conn):
             name_expr = f"unaccent(lower({self._name_col}))"
         else:

--- a/etter/datasources/swissboundaries3d.py
+++ b/etter/datasources/swissboundaries3d.py
@@ -7,7 +7,6 @@ search functionality with coordinate conversion to WGS84 GeoJSON.
 Data source: https://www.swisstopo.admin.ch/en/landscape-model-swissboundaries3d
 """
 
-import unicodedata
 from pathlib import Path
 from typing import Any
 
@@ -17,7 +16,9 @@ from geojson import Feature
 from shapely import force_2d
 from shapely.geometry import mapping
 
-from .location_types import TypeMap, fuzzy_search_index, get_matching_types, to_serializable
+from .geo_dataframe_source import GeoDataFrameSource
+from .location_types import TypeMap, get_matching_types, to_serializable
+from .text import normalize_name
 
 # Map normalized, grouped types to their OBJEKTART values.
 # Each type groups related OBJEKTART values (e.g., lake groups: See, Seeteil).
@@ -50,20 +51,7 @@ def _objektart_to_type(objektart: str) -> str:
     return objektart.lower()
 
 
-def _normalize_name(name: str) -> str:
-    """
-    Normalize a name for case-insensitive, accent-insensitive matching.
-
-    Strips diacritics (é→e, ü→u, etc.) and lowercases.
-    """
-    # Decompose unicode characters (é → e + combining accent)
-    nfkd = unicodedata.normalize("NFKD", name)
-    # Strip combining characters (accents, umlauts, etc.)
-    stripped = "".join(c for c in nfkd if not unicodedata.combining(c))
-    return stripped.lower().strip()
-
-
-class SwissBoundaries3DSource:
+class SwissBoundaries3DSource(GeoDataFrameSource):
     """
     Geographic data source backed by swisstopo's swissBOUNDARIES3D dataset.
 
@@ -98,16 +86,6 @@ class SwissBoundaries3DSource:
         self._type_col: str | None = None
         self._id_col: str | None = None
         self._extra_cols: list[str] = []
-
-    def preload(self) -> None:
-        """Eagerly load data. Call at startup to avoid first-query latency."""
-        self._ensure_loaded()
-
-    def _ensure_loaded(self) -> None:
-        """Load data lazily on first access."""
-        if self._gdf is not None:
-            return
-        self._load_data()
 
     def _load_data(self) -> None:
         """Load swissBoundaries3D data and build the name index."""
@@ -180,7 +158,7 @@ class SwissBoundaries3DSource:
         for idx, name in enumerate(self._gdf[self._name_col]):
             if not isinstance(name, str) or not name.strip():
                 continue
-            normalized = _normalize_name(name)
+            normalized = normalize_name(name)
             if normalized not in self._name_index:
                 self._name_index[normalized] = []
             self._name_index[normalized].append(idx)
@@ -273,7 +251,7 @@ class SwissBoundaries3DSource:
         """
         self._ensure_loaded()
 
-        normalized = _normalize_name(name)
+        normalized = normalize_name(name)
         indices = self._name_index.get(normalized, [])
 
         # If no exact match, try fuzzy matching
@@ -294,37 +272,6 @@ class SwissBoundaries3DSource:
                 features = [f for f in features if f["properties"].get("type") == type.lower()]
 
         return features[:max_results]
-
-    def _fuzzy_search(self, normalized: str, threshold: float = 75.0) -> list[int]:
-        return fuzzy_search_index(normalized, self._token_index, self._name_index, threshold)
-
-    def get_by_id(self, feature_id: str) -> Feature | None:
-        """
-        Get a specific feature by its unique identifier.
-
-        Args:
-            feature_id: Unique identifier (UUID or row index).
-
-        Returns:
-            The matching GeoJSON Feature dict, or None if not found.
-        """
-        self._ensure_loaded()
-        assert self._gdf is not None
-
-        if self._id_col:
-            matches = self._gdf[self._gdf[self._id_col].astype(str) == feature_id]
-            if not matches.empty:
-                return self._row_to_feature(matches.index[0])
-
-        # Fallback: try as row index
-        try:
-            idx = int(feature_id)
-            if 0 <= idx < len(self._gdf):
-                return self._row_to_feature(idx)
-        except ValueError:
-            pass
-
-        return None
 
     def get_available_types(self) -> list[str]:
         """

--- a/etter/datasources/swissnames3d.py
+++ b/etter/datasources/swissnames3d.py
@@ -7,7 +7,6 @@ search functionality with coordinate conversion to WGS84 GeoJSON.
 Data source: https://www.swisstopo.admin.ch/en/landscape-model-swissnames3d
 """
 
-import unicodedata
 from pathlib import Path
 from typing import Any
 
@@ -17,7 +16,9 @@ from geojson import Feature
 from shapely import force_2d
 from shapely.geometry import mapping
 
-from .location_types import TypeMap, fuzzy_search_index, get_matching_types, merge_segments, to_serializable
+from .geo_dataframe_source import GeoDataFrameSource
+from .location_types import TypeMap, get_matching_types, merge_segments, to_serializable
+from .text import normalize_name
 
 # Map normalized, grouped types to their OBJEKTART values.
 # Each type groups related OBJEKTART values (e.g., lake groups: See, Seeteil).
@@ -141,20 +142,7 @@ def _objektart_to_type(objektart: str) -> str:
     return objektart.lower()
 
 
-def _normalize_name(name: str) -> str:
-    """
-    Normalize a name for case-insensitive, accent-insensitive matching.
-
-    Strips diacritics (é→e, ü→u, etc.) and lowercases.
-    """
-    # Decompose unicode characters (é → e + combining accent)
-    nfkd = unicodedata.normalize("NFKD", name)
-    # Strip combining characters (accents, umlauts, etc.)
-    stripped = "".join(c for c in nfkd if not unicodedata.combining(c))
-    return stripped.lower().strip()
-
-
-class SwissNames3DSource:
+class SwissNames3DSource(GeoDataFrameSource):
     """
     Geographic data source backed by swisstopo's swissNAMES3D dataset.
 
@@ -186,16 +174,6 @@ class SwissNames3DSource:
         self._type_col: str | None = None
         self._id_col: str | None = None
         self._extra_cols: list[str] = []
-
-    def preload(self) -> None:
-        """Eagerly load data. Call at startup to avoid first-query latency."""
-        self._ensure_loaded()
-
-    def _ensure_loaded(self) -> None:
-        """Load data lazily on first access."""
-        if self._gdf is not None:
-            return
-        self._load_data()
 
     def _load_data(self) -> None:
         """Load SwissNames3D data and build the name index."""
@@ -264,7 +242,7 @@ class SwissNames3DSource:
         for idx, name in enumerate(self._gdf[self._name_col]):
             if not isinstance(name, str) or not name.strip():
                 continue
-            normalized = _normalize_name(name)
+            normalized = normalize_name(name)
             if normalized not in self._name_index:
                 self._name_index[normalized] = []
             self._name_index[normalized].append(idx)
@@ -362,7 +340,7 @@ class SwissNames3DSource:
         """
         self._ensure_loaded()
 
-        normalized = _normalize_name(name)
+        normalized = normalize_name(name)
         indices = self._name_index.get(normalized, [])
 
         # If no exact match, try fuzzy matching
@@ -385,37 +363,6 @@ class SwissNames3DSource:
 
         features = merge_segments(features)
         return features[:max_results]
-
-    def _fuzzy_search(self, normalized: str, threshold: float = 75.0) -> list[int]:
-        return fuzzy_search_index(normalized, self._token_index, self._name_index, threshold)
-
-    def get_by_id(self, feature_id: str) -> Feature | None:
-        """
-        Get a specific feature by its unique identifier.
-
-        Args:
-            feature_id: Unique identifier (UUID or row index).
-
-        Returns:
-            The matching GeoJSON Feature dict, or None if not found.
-        """
-        self._ensure_loaded()
-        assert self._gdf is not None
-
-        if self._id_col:
-            matches = self._gdf[self._gdf[self._id_col].astype(str) == feature_id]
-            if not matches.empty:
-                return self._row_to_feature(matches.index[0])
-
-        # Fallback: try as row index
-        try:
-            idx = int(feature_id)
-            if 0 <= idx < len(self._gdf):
-                return self._row_to_feature(idx)
-        except ValueError:
-            pass
-
-        return None
 
     def get_available_types(self) -> list[str]:
         """

--- a/etter/datasources/text.py
+++ b/etter/datasources/text.py
@@ -1,0 +1,9 @@
+"""Shared text-normalization helper for datasource name matching."""
+
+import unicodedata
+
+
+def normalize_name(name: str) -> str:
+    """Lowercase and strip diacritics (é→e, ü→u, etc.) for case-/accent-insensitive matching."""
+    nfkd = unicodedata.normalize("NFKD", name)
+    return "".join(c for c in nfkd if not unicodedata.combining(c)).lower().strip()


### PR DESCRIPTION
## Summary
- `_normalize_name` (accent-strip + lowercase) was duplicated identically across `swissnames3d.py`, `ign_bdcarto.py`, `swissboundaries3d.py`, and `postgis.py`. Extracted into `datasources/text.py` as `normalize_name()`, imported by all four.
- `preload()`, `_ensure_loaded()`, `_fuzzy_search()`, and `get_by_id()` were also duplicated across the three GeoDataFrame-backed sources (`SwissNames3DSource`, `IGNBDCartoSource`, `SwissBoundaries3DSource`). Extracted into a new `GeoDataFrameSource` base class (`datasources/geo_dataframe_source.py`), named after its backing store the same way `PostGISDataSource` is.
- `IGNBDCartoSource` gains a `self._id_col` attribute (previously a hardcoded `"cleabs"` string) so it can share `get_by_id()` with the other two sources.
- `get_available_types()` was **not** consolidated — despite two of the three sources having an identical body, `ign_bdcarto`'s is genuinely different logic, not shareable.
- No behavior change intended.

## Test plan
- [x] `pre-commit` (ruff check/format, ty) clean on all touched files.
- [x] Full suite (`uv run pytest`) matches the pre-refactor baseline across multiple runs: same pre-existing `test_multiple_disconnected_segments` failure, plus flaky LLM-inference tests in `test_context_aware_distances.py`/`test_contextual_distances.py` whose failing subset varies run-to-run independent of this change (confirmed non-deterministic, unrelated).
- [x] Targeted `tests/test_swissnames3d.py tests/test_ign_bdcarto.py` run clean (46 passed, same 1 pre-existing failure).