### PR TITLE
fix: fall back to a buffer for containment on point/line geometries

### DIFF
--- a/etter/spatial.py
+++ b/etter/spatial.py
@@ -150,7 +150,16 @@ def apply_spatial_relation(
         buffer_config = _refine_buffer_config(geom, buffer_config, relation)
 
     if relation.category == "containment":
-        result = geom_dict
+        if geom.geom_type in ("Point", "MultiPoint", "LineString", "MultiLineString"):
+            # A point/line reference can't meaningfully "contain" anything (a search
+            # target almost never touches an exact point or crosses a line exactly);
+            # fall back to a buffer sized from the reference's own (zero) area.
+            fallback_config = _refine_buffer_config(
+                geom, BufferConfig(distance_m=0, buffer_from="boundary", inferred=True), relation
+            )
+            result = _apply_buffer(geom, fallback_config)
+        else:
+            result = geom_dict
     elif relation.category == "buffer":
         if buffer_config is None:
             raise ValueError(f"Buffer relation '{relation.relation}' requires buffer_config")

--- a/tests/test_geometry_format.py
+++ b/tests/test_geometry_format.py
@@ -93,7 +93,8 @@ class TestApplySpatialRelationFormat:
         relation = SpatialRelation(relation="in", category="containment")
         result = apply_spatial_relation(POINT_GEOM, relation)
         assert isinstance(result, dict)
-        assert result["type"] == "Point"
+        # Containment on a point falls back to a buffer (see test_spatial.py).
+        assert result["type"] == "Polygon"
 
     def test_geojson_explicit(self):
         relation = SpatialRelation(relation="in", category="containment")
@@ -104,7 +105,8 @@ class TestApplySpatialRelationFormat:
         relation = SpatialRelation(relation="in", category="containment")
         result = apply_spatial_relation(POINT_GEOM, relation, geometry_format="wkt")
         assert isinstance(result, str)
-        assert result.startswith("POINT")
+        # Containment on a point falls back to a buffer (see test_spatial.py).
+        assert result.startswith("POLYGON")
 
     def test_wkb_containment(self):
         relation = SpatialRelation(relation="in", category="containment")

--- a/tests/test_spatial.py
+++ b/tests/test_spatial.py
@@ -8,13 +8,43 @@ from etter.models import BufferConfig, SpatialRelation
 from etter.spatial import apply_spatial_relation
 
 
-def test_containment_passthrough():
-    """Test that containment returns geometry unchanged."""
-    geom = {"type": "Point", "coordinates": [0, 0]}
+def test_containment_polygon_passthrough():
+    """Test that containment returns a polygon reference geometry unchanged."""
+    geom = {"type": "Polygon", "coordinates": [[[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]]}
     relation = SpatialRelation(relation="in", category="containment")
 
     result = apply_spatial_relation(geom, relation)
     assert result == geom
+
+
+def test_containment_point_falls_back_to_buffer():
+    """A point reference can't meaningfully "contain" anything; containment must
+    fall back to a buffer instead of the (near-always-empty) unchanged point."""
+    geom = {"type": "Point", "coordinates": [0, 0]}
+    relation = SpatialRelation(relation="in", category="containment")
+
+    result = apply_spatial_relation(geom, relation)
+
+    assert result["type"] != "Point"
+    result_shape = shape(result)
+    assert result_shape.area > 0
+    assert result_shape.contains(Point(0, 0))
+
+
+def test_containment_linestring_falls_back_to_buffer():
+    """A line reference falls back to a buffer covering its whole length, not just
+    a buffer around its centroid/midpoint."""
+    geom = {"type": "LineString", "coordinates": [[0.0, 0.0], [1.0, 0.0]]}
+    relation = SpatialRelation(relation="in", category="containment")
+
+    result = apply_spatial_relation(geom, relation)
+
+    assert result["type"] != "LineString"
+    result_shape = shape(result)
+    assert result_shape.area > 0
+    # Buffered along the whole line, not just around the midpoint.
+    assert result_shape.contains(Point(0.0, 0.0))
+    assert result_shape.contains(Point(1.0, 0.0))
 
 
 def test_around_buffer():


### PR DESCRIPTION
apply_spatial_relation's containment branch returned the reference geometry unchanged regardless of its type. That's correct for a polygon (e.g. "in Zürich" genuinely means intersecting the city boundary), but meaningless for a point or line reference (e.g. "in Niesen", a peak) — a search target essentially never touches an exact point or crosses a line exactly, so containment on those always returns empty results downstream.

Fall back to a buffer for Point/MultiPoint/LineString/MultiLineString, sized via the existing area-based inference (a zero-area reference lands in the smallest bracket, 500m). Polygon/MultiPolygon and any other geometry type keep the current unchanged-passthrough behavior.

Updates two pre-existing tests (test_spatial.py's containment test, test_geometry_format.py's containment format tests) that had asserted the point-passthrough behavior this fixes.