### PR TITLE
ci: publish demo Docker image to GHCR on push to main

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -61,3 +61,29 @@ jobs:
 
       - name: Publish to PyPI
         run: uv publish
+
+  publish-demo-image:
+    name: Build & push demo Docker image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v7
+      - uses: docker/setup-buildx-action@v4
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push demo image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: demo/Dockerfile
+          push: true
+          tags: |
+            ghcr.io/camptocamp/etter-demo:latest
+            ghcr.io/camptocamp/etter-demo:${{ github.sha }}


### PR DESCRIPTION
Adds a publish-demo-image job to the existing Publish workflow, building demo/Dockerfile and pushing to ghcr.io/camptocamp/etter-demo (tagged latest and the commit SHA), so the demo can be deployed outside PyPI's release cadence.